### PR TITLE
Remove unnecessary blank lines in main.c

### DIFF
--- a/main.c
+++ b/main.c
@@ -45,7 +45,6 @@
 static void
 sandbox_post(int fdin, int fdout)
 {
-
 	if (-1 == pledge("stdio", NULL))
 		err(EXIT_FAILURE, "pledge");
 }
@@ -53,7 +52,6 @@ sandbox_post(int fdin, int fdout)
 static void
 sandbox_pre(void)
 {
-
 	if (-1 == pledge("stdio rpath wpath cpath", NULL))
 		err(EXIT_FAILURE, "pledge");
 }
@@ -76,7 +74,6 @@ sandbox_post(int fdin, int fdout)
 static void
 sandbox_pre(void)
 {
-
 	/* Do nothing. */
 }
 
@@ -108,7 +105,6 @@ sandbox_post(int fdin, int fdout)
 static void
 sandbox_pre(void)
 {
-
 	/* Do nothing. */
 }
 
@@ -118,14 +114,12 @@ sandbox_pre(void)
 static void
 sandbox_post(int fdin, int fdout)
 {
-
 	/* Do nothing. */
 }
 
 static void
 sandbox_pre(void)
 {
-
 	/* Do nothing. */
 }
 
@@ -134,20 +128,17 @@ sandbox_pre(void)
 static void
 message(enum lowdown_err er, void *arg, const char *buf)
 {
-
 	if (NULL != buf)
 		fprintf(stderr, "%s: %s: %s\n", (const char *)arg,
 			lowdown_errstr(er), buf);
 	else
 		fprintf(stderr, "%s: %s\n", (const char *)arg,
 			lowdown_errstr(er));
-
 }
 
 static unsigned int
 feature_out(const char *v)
 {
-
 	if (NULL == v)
 		return(0);
 	if (0 == strcasecmp(v, "html-skiphtml"))
@@ -170,7 +161,6 @@ feature_out(const char *v)
 static unsigned int
 feature_in(const char *v)
 {
-
 	if (NULL == v)
 		return(0);
 	if (0 == strcasecmp(v, "tables"))


### PR DESCRIPTION
The blanks after the opening braces in functions seems unnecessary and inconsistent with the rest of the code base (especially the OpenBSD compat code).