### PR TITLE
Support YAML metadata delimiters

### DIFF
--- a/document.c
+++ b/document.c
@@ -3622,14 +3622,19 @@ lowdown_doc_parse(hdoc *doc, const char *data,
 	 */
 
 	if (LOWDOWN_METADATA & doc->ext_flags &&
-	    beg < size - 1 && isalnum((int)data[beg])) {
+	    beg < size - 1 && (isalnum((int)data[beg]) || '-' == data[beg])) {
 		sv = &data[beg];
+		if (0 == strncmp(sv, "---\n", 4)) {
+			beg += 4;
+			sv = &data[beg];
+		}
 		for (end = beg + 1; end < size; end++) {
 			if ('\n' == data[end] &&
 			    '\n' == data[end - 1])
 				break;
 		}
-		if (parse_metadata(doc, sv, end - beg))
+		int skip = (0 == strncmp(&data[end - 5], "\n---\n", 5)) ? 4 : 0;
+		if (parse_metadata(doc, sv, end - beg - skip))
 			beg = end + 1;
 	}
 


### PR DESCRIPTION
lowdown supports metadata blocks, which is great! However, it doesn’t support YAML metadata blocks (blocks surrounded by `---` lines). This PR adds trivial support for them by skipping the YAML metadata delimiters.

Given the following file:

~~~markdown
---
title: Example YAML metadata block
date: 2018-06-26
css: styles.css
---

The document content starts here.
~~~

`lowdown -X date` will return `2018-06-26` instead of `lowdown: date: unknown keyword` if this PR is merged.

### Details

YAML metadata blocks are supported by various Markdown parsers. [Pandoc](http://pandoc.org/MANUAL.html#extension-yaml_metadata_block) and [lcmark](https://github.com/jgm/lcmark#yaml-metadata) support them. [GitHub’s fork of cmark](https://github.com/github/cmark) renders them [as tables](https://gist.github.com/wolverian/649cbf802da678e9abf36055fc4c6dad). 

CommonMark does not specify YAML metadata; see e.g. [this post on the CommonMark discussion forum](https://talk.commonmark.org/t/standardized-metadata-layer/2429).

Pandoc and lcmark actually parse the YAML inside the metadata block so that metadata keys can point to any valid YAML object (instead of just strings). That doesn’t seem very useful to me without some kind of templating support to loop over and select sub-values, so this PR does not attempt to parse YAML.