### PR TITLE
Fix math rendering

### DIFF
--- a/document.c
+++ b/document.c
@@ -3780,6 +3780,9 @@ lowdown_node_free(struct lowdown_node *root)
 		hbuf_free(&root->rndr_image.dims);
 		hbuf_free(&root->rndr_image.alt);
 		break;
+	case (LOWDOWN_MATH_BLOCK):
+		hbuf_free(&root->rndr_math.text);
+		break;
 	default:
 		break;
 	}

--- a/document.c
+++ b/document.c
@@ -776,11 +776,8 @@ parse_math(hdoc *doc, char *data,
 	size_t offset, size_t size, const char *end, 
 	size_t delimsz, int displaymode)
 {
-	hbuf	 text;
 	size_t	 i = delimsz;
 	struct lowdown_node *n;
-
-	memset(&text, 0, sizeof(hbuf));
 
 	/* Find ending delimiter. */
 
@@ -799,11 +796,6 @@ parse_math(hdoc *doc, char *data,
 		i++;
 	}
 
-	/* Prepare buffers. */
-
-	text.data = data + delimsz;
-	text.size = i - delimsz;
-
 	/* 
 	 * If this is a $$ and MATH_EXPLICIT is not active, guess whether
 	 * displaymode should be enabled from the context.
@@ -818,6 +810,7 @@ parse_math(hdoc *doc, char *data,
 
 	n = pushnode(doc, LOWDOWN_MATH_BLOCK);
 	n->rndr_math.displaymode = displaymode;
+	pushbuffer(&n->rndr_math.text, data + delimsz, i - 2*delimsz);
 	popnode(doc, n);
 
 	return i;

--- a/html.c
+++ b/html.c
@@ -938,7 +938,7 @@ lowdown_html_rndr(hbuf *ob, void *ref, struct lowdown_node *root)
 			root->rndr_footnote_ref.num);
 		break;
 	case (LOWDOWN_MATH_BLOCK):
-		rndr_math(ob, tmp, root->rndr_math.displaymode);
+		rndr_math(ob, &root->rndr_math.text, root->rndr_math.displaymode);
 		break;
 	case (LOWDOWN_RAW_HTML):
 		rndr_raw_html(ob, &root->rndr_raw_html.text, ref);

--- a/lowdown.h
+++ b/lowdown.h
@@ -215,6 +215,7 @@ struct	lowdown_node {
 			hbuf alt; /* alt-text of image */
 		} rndr_image;
 		struct rndr_math {
+			hbuf text;
 			int displaymode;
 		} rndr_math;
 		struct rndr_blockhtml {


### PR DESCRIPTION
Currently math support (`-e math` and `-e mathexp`) appears to be broken. For example:

    $ax^2 + bx + 1$

Becomes

    \(\)

In the HTML output.

The previous code was creating a local `hbuf text`, and not returning it or storing it. This patch moves the `hbuf text` into `struct rndr_math`, and uses that to properly render the above as

    \(ax^2 + bx + 1\)