### PR TITLE
lowdown_doc_parse: Allow the 'nsz' argument to be null

### DIFF
--- a/document.c
+++ b/document.c
@@ -3997,7 +3997,8 @@ lowdown_doc_parse(struct lowdown_doc *doc,
 		free(m);
 	}
 
-	*nsz = doc->nodes;
+	if (nsz != NULL)
+		*nsz = doc->nodes;
 	popnode(doc, root);
 	assert(doc->depth == 0);
 	return root;


### PR DESCRIPTION
Examples in the manpages suggest that it should be possible to pass a
null pointer for this argument, e.g. in `lowdown_term_rndr.3`:

```
   if ((n = lowdown_doc_parse(doc, NULL, buf, bsz)) == NULL)
```