### PR TITLE
Manpage fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ HTMLS		 = archive.html \
 		   README.html \
 		   $(MANS)
 MANS		 = man/lowdown.1.html \
+		   man/lowdown-diff.1.html \
 		   man/lowdown.3.html \
 		   man/lowdown.5.html \
 		   man/lowdown_buf.3.html \

--- a/man/lowdown-diff.1
+++ b/man/lowdown-diff.1
@@ -1,0 +1,1 @@
+.so man1/lowdown.1

--- a/man/lowdown.1
+++ b/man/lowdown.1
@@ -586,7 +586,7 @@ To extract the HTML-escaped title from a file's metadata:
 .%A Wu Sun
 .%A Manber Udi
 .%A Myers Gene
-.%T An O(NP) sequence comparison algorithm
+.%T "An O(NP) sequence comparison algorithm"
 .%J Information Processing Letters
 .%V Volume 35
 .%I Issue 6

--- a/man/lowdown.1
+++ b/man/lowdown.1
@@ -365,7 +365,7 @@ Only used in
 .Fl T Ns Ar html .
 .It Li date
 Document date in ISO-8601 YYYY-MM-DD format.
-Overriden by
+Overridden by
 .Li rcsdate .
 Used in all output modes.
 .It Li javascript
@@ -450,7 +450,7 @@ may need to be used.
 ANSI-escaped UTF-8 output suitable for reading on the terminal.
 Images and equations not supported.
 .It Fl T Ns Ar tree
-Debugging ouptut: not for general use.
+Debugging output: not for general use.
 .El
 .Ss Diffing
 If invoked as

--- a/man/lowdown.3
+++ b/man/lowdown.3
@@ -21,6 +21,7 @@
 .Nm lowdown
 .Nd simple markdown translator library
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown.3
+++ b/man/lowdown.3
@@ -722,7 +722,7 @@ For
 .Dv LOWDOWN_TABLE_CELL ,
 the current
 .Va col
-colum number out of
+column number out of
 .Va columns .
 See
 .Va rndr_table_header

--- a/man/lowdown.5
+++ b/man/lowdown.5
@@ -613,7 +613,7 @@ brackets
 .Dq Pq \&[]
 followed by the URL or the path in parentheses
 .Dq Pq \&() .
-The parentheses may also contain optional dimenions
+The parentheses may also contain optional dimensions
 .Pq Ar width Ns x Ns Op Ar height
 starting with an equal sign or a quoted (single or double quotes) title
 in any order after the URL or path.

--- a/man/lowdown.5
+++ b/man/lowdown.5
@@ -1,3 +1,4 @@
+'\" t
 .\"	$Id$
 .\"
 .\" Copyright (c) 2017 Christina Sophonpanich <huck@divelog.blue>

--- a/man/lowdown_buf.3
+++ b/man/lowdown_buf.3
@@ -21,6 +21,7 @@
 .Nm lowdown_buf
 .Nd parse a Markdown buffer into formatted output
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_buf_diff.3
+++ b/man/lowdown_buf_diff.3
@@ -21,6 +21,7 @@
 .Nm lowdown_buf
 .Nd parse and diff Markdown buffers into formatted output
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_buf_free.3
+++ b/man/lowdown_buf_free.3
@@ -21,6 +21,7 @@
 .Nm lowdown_buf_free
 .Nd free a dynamic buffer
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_buf_new.3
+++ b/man/lowdown_buf_new.3
@@ -21,6 +21,7 @@
 .Nm lowdown_buf_new
 .Nd allocate a dynamic buffer
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_diff.3
+++ b/man/lowdown_diff.3
@@ -21,6 +21,7 @@
 .Nm lowdown_diff
 .Nd compute difference between parsed Markdown trees
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_diff.3
+++ b/man/lowdown_diff.3
@@ -64,7 +64,7 @@ tree.
 .%A Wu Sun
 .%A Manber Udi
 .%A Myers Gene
-.%T An O(NP) sequence comparison algorithm
+.%T "An O(NP) sequence comparison algorithm"
 .%J Information Processing Letters
 .%V Volume 35
 .%I Issue 6

--- a/man/lowdown_doc_free.3
+++ b/man/lowdown_doc_free.3
@@ -21,6 +21,7 @@
 .Nm lowdown_doc_free
 .Nd free a Markdown parser instance
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_doc_new.3
+++ b/man/lowdown_doc_new.3
@@ -21,6 +21,7 @@
 .Nm lowdown_doc_new
 .Nd allocate a Markdown parser
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_doc_parse.3
+++ b/man/lowdown_doc_parse.3
@@ -21,6 +21,7 @@
 .Nm lowdown_doc_parse
 .Nd parse a Markdown document into an AST
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_file.3
+++ b/man/lowdown_file.3
@@ -21,6 +21,7 @@
 .Nm lowdown_file
 .Nd parse a Markdown file into formatted output
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_file_diff.3
+++ b/man/lowdown_file_diff.3
@@ -21,6 +21,7 @@
 .Nm lowdown_file_diff
 .Nd parse and diff Markdown files into formatted output
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_gemini_free.3
+++ b/man/lowdown_gemini_free.3
@@ -21,6 +21,7 @@
 .Nm lowdown_gemini_free
 .Nd free a Markdown gemini renderer
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_gemini_new.3
+++ b/man/lowdown_gemini_new.3
@@ -21,6 +21,7 @@
 .Nm lowdown_gemini_new
 .Nd allocate a Markdown gemini renderer
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_gemini_rndr.3
+++ b/man/lowdown_gemini_rndr.3
@@ -21,6 +21,7 @@
 .Nm lowdown_gemini_rndr
 .Nd render Markdown into gemini
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_html_free.3
+++ b/man/lowdown_html_free.3
@@ -21,6 +21,7 @@
 .Nm lowdown_html_free
 .Nd free a Markdown HTML renderer
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_html_new.3
+++ b/man/lowdown_html_new.3
@@ -21,6 +21,7 @@
 .Nm lowdown_html_new
 .Nd allocate a Markdown HTML renderer
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_html_rndr.3
+++ b/man/lowdown_html_rndr.3
@@ -21,6 +21,7 @@
 .Nm lowdown_html_rndr
 .Nd render Markdown into HTML
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_latex_free.3
+++ b/man/lowdown_latex_free.3
@@ -21,6 +21,7 @@
 .Nm lowdown_latex_free
 .Nd free a Markdown LaTeX renderer
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_latex_new.3
+++ b/man/lowdown_latex_new.3
@@ -21,6 +21,7 @@
 .Nm lowdown_latex_new
 .Nd allocate a Markdown LaTeX renderer
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_latex_rndr.3
+++ b/man/lowdown_latex_rndr.3
@@ -21,6 +21,7 @@
 .Nm lowdown_latex_rndr
 .Nd render Markdown into LaTeX
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_metaq_free.3
+++ b/man/lowdown_metaq_free.3
@@ -21,6 +21,7 @@
 .Nm lowdown_metaq_free
 .Nd free rendered metadata key-value pairs
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_nroff_free.3
+++ b/man/lowdown_nroff_free.3
@@ -21,6 +21,7 @@
 .Nm lowdown_nroff_free
 .Nd free a Markdown roff renderer
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_nroff_new.3
+++ b/man/lowdown_nroff_new.3
@@ -21,6 +21,7 @@
 .Nm lowdown_nroff_new
 .Nd allocate a roff renderer for lowdown documents
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_nroff_rndr.3
+++ b/man/lowdown_nroff_rndr.3
@@ -21,6 +21,7 @@
 .Nm lowdown_nroff_rndr
 .Nd render Markdown into roff
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_term_free.3
+++ b/man/lowdown_term_free.3
@@ -21,6 +21,7 @@
 .Nm lowdown_term_free
 .Nd free an Markdown terminal renderer
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_term_new.3
+++ b/man/lowdown_term_new.3
@@ -21,6 +21,7 @@
 .Nm lowdown_term_new
 .Nd allocate a Markdown terminal renderer
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_term_rndr.3
+++ b/man/lowdown_term_rndr.3
@@ -21,6 +21,7 @@
 .Nm lowdown_term_rndr
 .Nd render Markdown into terminal output
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_tree_free.3
+++ b/man/lowdown_tree_free.3
@@ -21,6 +21,7 @@
 .Nm lowdown_tree_free
 .Nd free a Markdown debugging renderer
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_tree_new.3
+++ b/man/lowdown_tree_new.3
@@ -21,6 +21,7 @@
 .Nm lowdown_tree_new
 .Nd allocate a Markdown debugging renderer
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h

--- a/man/lowdown_tree_rndr.3
+++ b/man/lowdown_tree_rndr.3
@@ -21,6 +21,7 @@
 .Nm lowdown_tree_rndr
 .Nd render Markdown into debugging output
 .Sh LIBRARY
+.ds doc-str-Lb-liblowdown simple markdown translator library
 .Lb liblowdown
 .Sh SYNOPSIS
 .In sys/queue.h


### PR DESCRIPTION
This fixes a bunch of issues with manpages. All were identified using Debian's lintian. With the exception of typos the easiest way to reproduce these is with:
`LC_ALL=en_US.UTF-8 MANROFFSEQ='' MANWIDTH=80 man --warnings -E UTF-8 -l -Tutf8 -Z file > /dev/null`