### PR TITLE
[WIP] Add command line options for specifying metadata

### DIFF
--- a/document.c
+++ b/document.c
@@ -4088,6 +4088,14 @@ lowdown_node_free(struct lowdown_node *root)
 }
 
 void
+lowdown_meta_free(struct lowdown_meta *m)
+{
+	free(m->key);
+	free(m->value);
+	free(m);
+}
+
+void
 lowdown_metaq_free(struct lowdown_metaq *q)
 {
 	struct lowdown_meta	*m;
@@ -4097,9 +4105,7 @@ lowdown_metaq_free(struct lowdown_metaq *q)
 
 	while ((m = TAILQ_FIRST(q)) != NULL) {
 		TAILQ_REMOVE(q, m, entries);
-		free(m->key);
-		free(m->value);
-		free(m);
+		lowdown_meta_free(m);
 	}
 }
 

--- a/lowdown.h
+++ b/lowdown.h
@@ -302,6 +302,8 @@ struct	lowdown_opts {
 	size_t			 hmargin; /* -Tterm left margin */
 	size_t			 vmargin; /* -Tterm top/bot margin */
 	unsigned int		 feat;
+	struct lowdown_metaq	 meta;
+	struct lowdown_metaq	 metaovr;
 #define LOWDOWN_TABLES		 0x01
 #define LOWDOWN_FENCED		 0x02
 #define LOWDOWN_FOOTNOTES	 0x04

--- a/lowdown.h
+++ b/lowdown.h
@@ -378,6 +378,7 @@ struct lowdown_node
 	*lowdown_diff(const struct lowdown_node *,
 		const struct lowdown_node *, size_t *);
 void	 lowdown_doc_free(struct lowdown_doc *);
+void	 lowdown_meta_free(struct lowdown_meta *);
 void	 lowdown_metaq_free(struct lowdown_metaq *);
 
 void 	 lowdown_node_free(struct lowdown_node *);


### PR DESCRIPTION
Addresses most of #49 (doesn't touch the `header` metadata entry yet)

I'm opening this PR in a WIP state because I'd like to have your thoughts on my current approach. I should note that I have yet to decide on the implementation for parsing the command line parameters, so for now it's just some hardocoded values (I would appreciate your input on the amount of validation that should be performed here).

EDIT: now implements parsing for the command line parameters. They are required to have some value. Should we cover the situation where someone wants to use `-M "title:"` to explicitly remove a parameter?

As mentioned in https://github.com/kristapsdz/lowdown/issues/49#issuecomment-759833127, I'm removing the metadata information from the queues filled up while parsing the command line arguments as soon as it matches a key from the document's metadata. This makes it so I can simply loop through the remaining metadata in order to add it to the final document. However, this approach means I need to modify the queue, which forced me to remove the `const` qualifier from the `opts` member of the `lowdown_doc` struct. Can you think of an alternative method of pushing the metadata into the document that doesn't require removing `const` from there? Alternatively, could I add function parameters and fields inside `lowdown_doc` specifically for these queues? That way they wouldn't be associated to `opts` and we wouldn't have to touch its constness.

That comment also touches upon the limitation that this doesn't try to deal with repeated key values in the metadata. Since the current implementation doesn't really consider that either, I didn't consider it necessary to mention in a comment in the code. But it might be reasonable to add it to documentation?