### PR TITLE
Add source and volume to TH in -Tman output.

### DIFF
--- a/man/lowdown.1
+++ b/man/lowdown.1
@@ -391,6 +391,12 @@ Man page section, defaulting to
 .Dq 7 .
 Only used in
 .Fl T Ns Ar man .
+.It Li source
+Man page source. Only used in
+.Fl T Ns Ar man .
+.It Li volume
+Man page volume. Only used in
+.Fl T Ns Ar man .
 .It Li title
 Document title, defaulting to
 .Dq Untitled article .

--- a/nroff.c
+++ b/nroff.c
@@ -1178,7 +1178,8 @@ rndr_doc_header(struct lowdown_buf *ob,
 	const char			*author = NULL, *title = NULL,
 					*affil = NULL, *date = NULL,
 					*copy = NULL, *section = NULL,
-					*rcsauthor = NULL, *rcsdate = NULL;
+					*rcsauthor = NULL, *rcsdate = NULL,
+					*source = NULL, *volume = NULL;
 
 	if (!(st->flags & LOWDOWN_STANDALONE))
 		return;
@@ -1200,6 +1201,10 @@ rndr_doc_header(struct lowdown_buf *ob,
 			title = m->value;
 		else if (strcasecmp(m->key, "section") == 0)
 			section = m->value;
+		else if (strcasecmp(m->key, "source") == 0)
+			source = m->value;
+		else if (strcasecmp(m->key, "volume") == 0)
+			volume = m->value;
 
 	/* Overrides. */
 
@@ -1241,14 +1246,35 @@ rndr_doc_header(struct lowdown_buf *ob,
 		if (affil != NULL)
 			rndr_meta_multi(ob, affil, "AI");
 	} else {
+		/* .TH name section date [source [volume]] */
+
 		HBUF_PUTSL(ob, ".TH \"");
 		rndr_one_line_noescape(ob, title, strlen(title), 0);
 		HBUF_PUTSL(ob, "\" ");
 		rndr_one_line_noescape(ob, section, strlen(section), 0);
 		if (date != NULL) {
-			HBUF_PUTSL(ob, " ");
+			HBUF_PUTSL(ob, " \"");
 			rndr_one_line_noescape
 				(ob, date, strlen(date), 0);
+			HBUF_PUTSL(ob, "\"");
+		} else {
+			HBUF_PUTSL(ob, " \"\"");
+		}
+		if (source != NULL) {
+			HBUF_PUTSL(ob, " \"");
+			rndr_one_line_noescape
+				(ob, source, strlen(source), 0);
+			HBUF_PUTSL(ob, "\"");
+		} else {
+			HBUF_PUTSL(ob, " \"\"");
+		}
+		if (volume != NULL) {
+			HBUF_PUTSL(ob, " \"");
+			rndr_one_line_noescape
+				(ob, volume, strlen(volume), 0);
+			HBUF_PUTSL(ob, "\"");
+		} else {
+			HBUF_PUTSL(ob, " \"\"");
 		}
 		HBUF_PUTSL(ob, "\n");
 	}


### PR DESCRIPTION
The TH macro will always receive 5 values now, though some of them might
be empty (""). The new metadata keys are 'source' and 'volume'. pandoc
uses 'header' for what it puts in 'volume', but it's more consistent to
follow the naming from man(7).

Since 'date' isn't guaranteed to not have spaces, put quotes around it.

Also update lowdown(1) for the new supported metadata keys.

Addresses the rest of #49 