### PR TITLE
Remove test for rsquo only at right word boundary

### DIFF
--- a/smartypants.c
+++ b/smartypants.c
@@ -358,8 +358,6 @@ smarty_hbuf(struct lowdown_node *n, size_t *maxn,
 			/* Left-wb and right-wb differ. */
 
 			if (!s->left_wb) {
-				if (!smarty_right_wb(n, i + 1))
-					break;
 				if (!smarty_entity(n, maxn, 
 				    i, i + 1, ENT_RSQUO))
 					return -1;


### PR DESCRIPTION
This allows apostrophes within contraction words, e.g. "I'm"

Full disclosure, I have no idea what I'm doing here as I don't yet know C, but after testing this it seems I hit upon the right test statement :)