### PR TITLE
Fix troff compatibility & allow overriding horizontal rule in -Tms.

### DIFF
--- a/nroff.c
+++ b/nroff.c
@@ -995,18 +995,19 @@ rndr_raw_block(const struct nroff *st,
 }
 
 static int
-rndr_hrule(const struct nroff *st, struct bnodeq *obq)
+rndr_hrule(struct nroff *st, struct bnodeq *obq)
 {
-	/*
-	 * I'm not sure how else to do horizontal lines.
-	 * The LP is to reset the margins.
-	 */
+	/* The LP is to reset the margins. */
 
 	if (bqueue_block(obq, ".LP") == NULL)
 		return 0;
 	if (!st->man && 
-	    bqueue_block(obq, "\\l\'\\n(.lu-\\n(\\n[.in]u\'") == NULL)
+	    bqueue_block(obq, ".ie d HR \\{\\\n.HR\n\\}\n.el \\{\\\n.sp 1v\n\\l'\\n(.liu'\n.sp 1v\n.\\}") == NULL)
 		return 0;
+
+	/* Set post_para so we get a following LP not PP. */
+
+	st->post_para = 1;
 	return 1;
 }
 


### PR DESCRIPTION
This commit does three things for **-Tms** output:

Fixes the generation of a horizontal rule for compatibility with (Heirloom) troff. This only removes the calculation of indent, which is removed with the previous `LP` call anyway.

Adds a single line of vertical space on either side of a horizontal line.

Allows the user to define a `HR` macro, which, if defined, will be used in place of the generated horizontal rule. This allows for fancy literary styles of typesetting.

I did try to use `HBUF_PUTSL` but it wouldn't compile, giving me:
```c
nroff.c:1005:35: error: use of undeclared identifier 'ob'
            bqueue_block(obq, HBUF_PUTSL(ob, ".ie d HR \\{\\\n"
                                         ^
```
If you're able to massage this PR to correctly use `HBUFPUTSL` I would be grateful :)

Resolves #78 