### PR TITLE
liblowdown: add a symlink for the install phase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ install_lib_common: lowdown.pc
 
 install_shared: liblowdown.so install_lib_common
 	$(INSTALL_LIB) liblowdown.so.$(LIBVER) $(DESTDIR)$(LIBDIR)
+	( cd $(DESTDIR)$(LIBDIR) ; ln -sf liblowdown.so.$(LIBVER) liblowdown.so )
 
 install_static: liblowdown.a install_lib_common
 	$(INSTALL_LIB) liblowdown.a $(DESTDIR)$(LIBDIR)


### PR DESCRIPTION
Hello,

Is it possible to add a symlink after the install in the DESTDIR?

NOTE: I also noticed that the permissions of liblowdown is not good after the install.