### PR TITLE
Recognise the "lang" metadata tag

### DIFF
--- a/man/lowdown.1
+++ b/man/lowdown.1
@@ -557,6 +557,10 @@ Multiple script files (in order) may be separated by two or more spaces
 (including newlines).
 Only used in
 .Fl t Ns Ar html .
+.It Li lang
+Document language in RFC 5646 format.
+Only used in
+.Fl t Ns Ar html .
 .It Li rcsauthor
 Like
 .Li author ,

--- a/regress/standalone/html-meta-lang.html
+++ b/regress/standalone/html-meta-lang.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Untitled article</title>
+</head>
+<body>
+
+<p>hello, world</p>
+</body>
+</html>

--- a/regress/standalone/html-meta-lang.md
+++ b/regress/standalone/html-meta-lang.md
@@ -1,0 +1,3 @@
+lang: en
+
+hello, world


### PR DESCRIPTION
This is needed to generate accessible HTML documents using lowdown.