### PR TITLE
Allow meta and link tags in documents

### DIFF
--- a/document.c
+++ b/document.c
@@ -3304,6 +3304,41 @@ parse_htmlblock(struct lowdown_doc *doc, char *data, size_t size)
 			}
 		}
 
+		/*
+		 * META and LINK, which are technically not block tags
+		 * but are allowed in HTML5 bodies.
+		 */
+		if (size > 6 &&
+		    (((data[1] == 'm' || data[1] == 'M') &&
+		    (data[2] == 'e' || data[2] == 'E') &&
+		    (data[3] == 't' || data[3] == 'T') &&
+		    (data[4] == 'a' || data[4] == 'A')) ||
+		    ((data[1] == 'l' || data[1] == 'L') &&
+		    (data[2] == 'i' || data[2] == 'I') &&
+		    (data[3] == 'n' || data[3] == 'N') &&
+		    (data[4] == 'k' || data[4] == 'K')))) {
+			i = 5;
+			while (i < size && data[i] != '>')
+				i++;
+			if (i + 1 < size) {
+				i++;
+				j = is_empty(data + i, size - 1);
+				if (j) {
+					n = pushnode(doc,
+						LOWDOWN_BLOCKHTML);
+					if (n == NULL)
+						return -1;
+					work.size = i + j;
+					if (!hbuf_createb
+					    (&n->rndr_blockhtml.text,
+					     &work))
+						return -1;
+					popnode(doc, n);
+					return work.size;
+				}
+			}
+		}
+
 		/* No special case recognised. */
 
 		return 0;

--- a/man/lowdown.5
+++ b/man/lowdown.5
@@ -527,7 +527,9 @@ Accepted elements are
 .Li <table> ,
 .Li <ul> ,
 and self-closing
-.Li <hr /> .
+.Li <hr /> ,
+.Li <link /> ,
+.Li <meta /> .
 .Sh SPAN ELEMENTS
 Span elements are inline elements (including normal text) within block
 elements, for example, a span of emphasised text or a hyperlink.


### PR DESCRIPTION
While lowdown has its own metadata system (which is great btw!) some tools and workflows rely on embedding metadata with simple `<meta/>` and `<link/>` tags in documents, for example when building RDFa documents with rich data.

This pull request makes it possible to embed `<meta/>` and `<link/>` tags in the body of a document, similarly to self-closing `<hr/>`.

While technically not HTML5 block elements, both tags are allowed in HTML5 bodies. For example, here's an valid HTML5/RDFa document:

```
<!DOCTYPE html>
<html typeof="schema:webpage" resource="/hello" lang="en">
<head>
<title>Hello</title>
</head>
<body>
<meta property="schema:author" content="Bar"/>
<link property="schema:workTranslation" lang="fr" href="/bonjour"/>
<link property="schema:workTranslation" lang="sv" href="/hejsan"/>
<h1>Hello</h1>
</body>
</html>
```

The above code snippet can be validated with the following services:

* HTML5: https://validator.w3.org/
* RDFa: https://validator.schema.org/