### PR TITLE
Add initial support for the wasm32-wasi target

### DIFF
--- a/main.c
+++ b/main.c
@@ -137,7 +137,9 @@ sandbox_pre(void)
 
 #else /* No sandbox. */
 
+#ifndef __wasi__ /* WebAssembly is always sandboxed */
 #warning Compiling without sandbox support.
+#endif
 
 static void
 sandbox_post(int fdin, int fddin, int fdout)

--- a/main.c
+++ b/main.c
@@ -43,7 +43,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef __wasi__
 #include <termios.h> /* struct winsize */
+#endif
 #include <unistd.h>
 
 #include "lowdown.h"
@@ -156,12 +158,16 @@ sandbox_pre(void)
 static size_t
 get_columns(void)
 {
+#ifndef __wasi__
 	struct winsize	 size;
 
 	memset(&size, 0, sizeof(struct winsize));
 	if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &size) == -1)
 		return 72;
 	return size.ws_col;
+#else
+	return 72;
+#endif
 }
 
 /*


### PR DESCRIPTION
I have successfully built lowdown to WebAssembly, using the wasm32-wasi target. The resulting wasm binary can be executed locally with wasmtime (`wasmtime lowdown`), wasmer (`wasmer lowdown`) and wasmedge, or deployed in a serverless cloud.I had success with all three, using Cloudflare Workers for the latter, with their [brand new WASI support](https://blog.cloudflare.com/announcing-wasi-on-workers/).

The changes required are #98, kristapsdz/oconfigure#23, kristapsdz/oconfigure#24, and this change. Beyond those, the following issues remain:
- Some of the compatibility functions in compats.c cannot be built, due to various pieces of functionality WebAssembly does not provide (and may never provide). However, these are not actually used by lowdown, but just exist for other oconfigure consumers. So, after running configure, I overrode config.h to pretend these exist and hence disable the compats. implementation. This can be accomplished with `sed -i -r 's/HAVE_(MKFIFOAT|MKNODAT|FTS|B64_NTOP|READPASSPHRASE|SETRESGID|SETRESUID) 0/HAVE_\1 1/' config.h
`
- liblowdown.so cannot be built, as shared objects are not supported (yet?). `make lowdown` needs to be used.
- ~~wasi-libc does not provide `getpagesize()` that the bundled `recallocarray()` requires. Easily worked around by replacing it with `sysconf(_SC_PAGE_SIZE)`, but I've also asked wasi-libc upstream to add the (trivial) implementation as well (WebAssembly/wasi-libc#299)~~ (edit: this is now fixed)

Necessary pieces are: a clang supporting the wasm32-wasi target, compiler-rt built for wasm32-wasi and wasi-sysroot (w/ wasi-libc). All of those provided by the [wasi-sdk](https://github.com/WebAssembly/wasi-sdk/).

The command-line to build would be:
`AR=llvm-ar CC=clang CFLAGS="--target=wasm32-wasi --sysroot=/opt/wasi-sysroot" ./configure LDFLAGS="--rtlib=compiler-rt"`