### PR TITLE
Link liblowdown with -lm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ liblowdown.a: $(OBJS) $(COMPAT_OBJS)
 	$(AR) rs $@ $(OBJS) $(COMPAT_OBJS)
 
 liblowdown.so: $(OBJS) $(COMPAT_OBJS)
-	$(CC) -shared -o $@.$(LIBVER) $(OBJS) $(COMPAT_OBJS) $(LDFLAGS) $(LDADD_MD5) -Wl,-soname,$@.$(LIBVER)
+	$(CC) -shared -o $@.$(LIBVER) $(OBJS) $(COMPAT_OBJS) $(LDFLAGS) $(LDADD_MD5) -lm -Wl,-soname,$@.$(LIBVER)
 	ln -sf $@.$(LIBVER) $@
 
 install: bins


### PR DESCRIPTION
liblowdown uses symbols from libm, such as log(), and does not link with it unlike the main lowdown binary. Add -lm to the CC invocation to do so.