### PR TITLE
More spelling fixes

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -521,7 +521,7 @@ match_singleton(const struct lowdown_node *n)
 }
 
 /*
- * Algorithm to "propogate up" according to "Phase 3" of sec. 5.2.
+ * Algorithm to "propagate up" according to "Phase 3" of sec. 5.2.
  * This also uses the heuristic described in "Tuning" for how many
  * levels to search upward.
  * I augment this by making singleton children pass upward.
@@ -580,7 +580,7 @@ match_up(struct xnode *xnew, struct xmap *xnewmap,
 }
 
 /*
- * Algorithm that "propogates down" according to "Phase 3" of sec. 5.2.
+ * Algorithm that "propagates down" according to "Phase 3" of sec. 5.2.
  * This (recursively) makes sure that a matched tree has all of the
  * subtree nodes also matched.
  */

--- a/diff.md
+++ b/diff.md
@@ -181,8 +181,8 @@ begins with a short sanitisation pass.
     4. If the no candidates were found, enqueue the node's children into
        the priority queue.
     5. A a candidate was selected, mark all of its subtree nodes as
-       matching the corresponding nodes in the old tree ("propogate
-       down"), then mark ancestor nodes similarly ("propogate up").
+       matching the corresponding nodes in the old tree ("propagate
+       down"), then mark ancestor nodes similarly ("propagate up").
        ([diff.c](https://github.com/kristapsdz/lowdown/blob/master/diff.c),
        `match_up()`, `match_down()`)
 
@@ -240,15 +240,15 @@ In the event of similar optimality, the node "closest" to the current
 node is chosen.  Proximity is defined by the node identifier, which is
 its prefix order in the parse tree.
 
-### "Propogate up"
+### "Propagate up"
 
-When propogating a match upward, the distance upward is bound depending
+When propagating a match upward, the distance upward is bound depending
 on the matched sub-tree as defined in the paper.  This makes it so that
 "small" similarities (such as text) don't erroneously match two larger
 sub-trees that are otherwise different.  Upward matches occur while the
 nodes' labels are the same, including attributes (e.g., link text).
 
-I did modify the algorithm to propogate upward "for free" through
+I did modify the algorithm to propagate upward "for free" through
 similar singleton nodes, even if it means going beyond the maximum
 number allowed by the sub-tree weight.
 
@@ -256,7 +256,7 @@ number allowed by the sub-tree weight.
 
 The [lowdown-diff(1)](https://kristaps.bsd.lv/lowdown/lowdown.1.html)
 algorithm has two optimisations, both lightly derived from the paper:
-top-down and bottom-up propogation.
+top-down and bottom-up propagation.
 
 #### Top-down
 
@@ -271,8 +271,8 @@ difference downward in the tree.
 
 #### Bottom-up
 
-In the bottom-up propogation, the weight of any given sub-tree is used
-to compute how high a match will propogate.  I extend the paper's
+In the bottom-up propagation, the weight of any given sub-tree is used
+to compute how high a match will propagate.  I extend the paper's
 version optimisation by looking at the cumulative weight of matching
 children.
 
@@ -291,7 +291,7 @@ The merging phase, which is not described in the paper, is very
 straightforward.  It uses a recursive merge algorithm starting at the
 root node of the new tree and the root node of the old tree.
 
-1. The invariant is that the current node is matched by the corresonding
+1. The invariant is that the current node is matched by the corresponding
    node in the old tree.
 2. First, step through child nodes in the old tree.  Mark as deleted all
    nodes not being matched to the new tree.

--- a/diff.old.md
+++ b/diff.old.md
@@ -160,8 +160,8 @@ begins with a short sanitisation pass.
     4. If the no candidates were found, enqueue the node's children into
        the priority queue.
     5. A a candidate was selected, mark all of its subtree nodes as
-       matching the corresponding nodes in the old tree ("propogate
-       down"), then mark ancestor nodes similarly ("propogate up").
+       matching the corresponding nodes in the old tree ("propagate
+       down"), then mark ancestor nodes similarly ("propagate up").
        ([diff.c](https://github.com/kristapsdz/lowdown/blob/master/diff.c),
        `match_up()`, `match_down()`)
 
@@ -219,15 +219,15 @@ In the event of similar optimality, the node "closest" to the current
 node is chosen.  Proximity is defined by the node identifier, which is
 its prefix order in the parse tree.
 
-### "Propogate up"
+### "Propagate up"
 
-When propogating a match upward, the distance upward is bound depending
+When propagating a match upward, the distance upward is bound depending
 on the matched sub-tree as defined in the paper.  This makes it so that
 "small" similarities (such as text) don't erroneously match two larger
 sub-trees that are otherwise different.  Upward matches occur while the
 nodes' labels are the same, including attributes (e.g., link text).
 
-I did modify the algorithm to propogate upward "for free" through
+I did modify the algorithm to propagate upward "for free" through
 similar singleton nodes, even if it means going beyond the maximum
 number allowed by the sub-tree weight.
 
@@ -235,7 +235,7 @@ number allowed by the sub-tree weight.
 
 The [lowdown-diff(1)](https://kristaps.bsd.lv/lowdown/lowdown.1.html)
 algorithm has two optimisations, both lightly derived from the paper:
-top-down and bottom-up propogation.
+top-down and bottom-up propagation.
 
 #### Top-down
 
@@ -249,8 +249,8 @@ difference downward in the tree.
 
 #### Bottom-up
 
-In the bottom-up propogation, the weight of any given sub-tree is used
-to compute how high a match will propogate.  I extend the paper's
+In the bottom-up propagation, the weight of any given sub-tree is used
+to compute how high a match will propagate.  I extend the paper's
 version optimisation by looking at the cumulative weight of matching
 children.
 
@@ -269,7 +269,7 @@ The merging phase, which is not described in the paper, is very
 straightforward.  It uses a recursive merge algorithm starting at the
 root node of the new tree and the root node of the old tree.
 
-1. The invariant is that the current node is matched by the corresonding
+1. The invariant is that the current node is matched by the corresponding
    node in the old tree.
 2. First, step through child nodes in the old tree.  Mark as deleted all
    nodes not being matched to the new tree.

--- a/man/lowdown.5
+++ b/man/lowdown.5
@@ -655,7 +655,7 @@ Attributes are separated by spaces.
 .Pp
 Values with a leading period
 .Pq Qq \&.class
-are interpreted as HTML (CSS) or OpenDocument classses, and values with
+are interpreted as HTML (CSS) or OpenDocument classes, and values with
 a leading pound symbol
 .Pq Qq \&#id
 are interpreted as in-document link identifiers.

--- a/nroff.c
+++ b/nroff.c
@@ -93,7 +93,7 @@ static const size_t NROFF_MIN_LI_MARK_WIDTH = 3;
 TAILQ_HEAD(bnodeq, bnode);
 
 /*
- * Escape unsafe text into roff output such that no roff fetaures are
+ * Escape unsafe text into roff output such that no roff features are
  * invoked by the text (macros, escapes, etc.).
  * If "oneline" is non-zero, newlines are replaced with spaces.
  * If "literal", doesn't strip leading space.

--- a/regress/diff/diff.html
+++ b/regress/diff/diff.html
@@ -176,8 +176,8 @@ popped node&#8217;s hash.
 <li>If the no candidates were found, enqueue the node&#8217;s children into
 the priority queue.</li>
 <li>A a candidate was selected, mark all of its subtree nodes as
-matching the corresponding nodes in the old tree (&#8220;propogate
-down&#8221;), then mark ancestor nodes similarly (&#8220;propogate up&#8221;).
+matching the corresponding nodes in the old tree (&#8220;propagate
+down&#8221;), then mark ancestor nodes similarly (&#8220;propagate up&#8221;).
 (<a href="https://github.com/kristapsdz/lowdown/blob/master/diff.c">diff.c</a>,
 <code>match_up()</code>, <code>match_down()</code>)</li>
 </ol></li>
@@ -235,15 +235,15 @@ weight of the sub-tree as defined in the paper.</p>
 node is chosen.  Proximity is defined by the node identifier, which is
 its prefix order in the parse tree.</p>
 
-<h3 id="propogate-up">&#8220;Propogate up&#8221;</h3>
+<h3 id="propagate-up">&#8220;Propagate up&#8221;</h3>
 
-<p>When propogating a match upward, the distance upward is bound depending
+<p>When propagating a match upward, the distance upward is bound depending
 on the matched sub-tree as defined in the paper.  This makes it so that
 &#8220;small&#8221; similarities (such as text) don&#8217;t erroneously match two larger
 sub-trees that are otherwise different.  Upward matches occur while the
 nodes&#8217; labels are the same, including attributes (e.g., link text).</p>
 
-<p>I did modify the algorithm to propogate upward &#8220;for free&#8221; through
+<p>I did modify the algorithm to propagate upward &#8220;for free&#8221; through
 similar singleton nodes, even if it means going beyond the maximum
 number allowed by the sub-tree weight.</p>
 
@@ -251,7 +251,7 @@ number allowed by the sub-tree weight.</p>
 
 <p>The <a href="https://kristaps.bsd.lv/lowdown/lowdown.1.html">lowdown-diff(1)</a>
 algorithm has two optimisations, both lightly derived from the paper:
-top-down and bottom-up propogation.</p>
+top-down and bottom-up propagation.</p>
 
 <h4 id="top-down">Top-down</h4>
 
@@ -264,8 +264,8 @@ difference downward in the tree.</p>
 
 <h4 id="bottom-up">Bottom-up</h4>
 
-<p>In the bottom-up propogation, the weight of any given sub-tree is used
-to compute how high a match will propogate.  I extend the paper&#8217;s
+<p>In the bottom-up propagation, the weight of any given sub-tree is used
+to compute how high a match will propagate.  I extend the paper&#8217;s
 version optimisation by looking at the cumulative weight of matching
 children.</p>
 
@@ -285,7 +285,7 @@ straightforward.  It uses a recursive merge algorithm starting at the
 root node of the new tree and the root node of the old tree.</p>
 
 <ol>
-<li>The invariant is that the current node is matched by the corresonding
+<li>The invariant is that the current node is matched by the corresponding
 node in the old tree.</li>
 <li>First, step through child nodes in the old tree.  Mark as deleted all
 nodes not being matched to the new tree.</li>

--- a/regress/diff/diff.new.md
+++ b/regress/diff/diff.new.md
@@ -181,8 +181,8 @@ begins with a short sanitisation pass.
     4. If the no candidates were found, enqueue the node's children into
        the priority queue.
     5. A a candidate was selected, mark all of its subtree nodes as
-       matching the corresponding nodes in the old tree ("propogate
-       down"), then mark ancestor nodes similarly ("propogate up").
+       matching the corresponding nodes in the old tree ("propagate
+       down"), then mark ancestor nodes similarly ("propagate up").
        ([diff.c](https://github.com/kristapsdz/lowdown/blob/master/diff.c),
        `match_up()`, `match_down()`)
 
@@ -240,15 +240,15 @@ In the event of similar optimality, the node "closest" to the current
 node is chosen.  Proximity is defined by the node identifier, which is
 its prefix order in the parse tree.
 
-### "Propogate up"
+### "Propagate up"
 
-When propogating a match upward, the distance upward is bound depending
+When propagating a match upward, the distance upward is bound depending
 on the matched sub-tree as defined in the paper.  This makes it so that
 "small" similarities (such as text) don't erroneously match two larger
 sub-trees that are otherwise different.  Upward matches occur while the
 nodes' labels are the same, including attributes (e.g., link text).
 
-I did modify the algorithm to propogate upward "for free" through
+I did modify the algorithm to propagate upward "for free" through
 similar singleton nodes, even if it means going beyond the maximum
 number allowed by the sub-tree weight.
 
@@ -256,7 +256,7 @@ number allowed by the sub-tree weight.
 
 The [lowdown-diff(1)](https://kristaps.bsd.lv/lowdown/lowdown.1.html)
 algorithm has two optimisations, both lightly derived from the paper:
-top-down and bottom-up propogation.
+top-down and bottom-up propagation.
 
 #### Top-down
 
@@ -271,8 +271,8 @@ difference downward in the tree.
 
 #### Bottom-up
 
-In the bottom-up propogation, the weight of any given sub-tree is used
-to compute how high a match will propogate.  I extend the paper's
+In the bottom-up propagation, the weight of any given sub-tree is used
+to compute how high a match will propagate.  I extend the paper's
 version optimisation by looking at the cumulative weight of matching
 children.
 
@@ -291,7 +291,7 @@ The merging phase, which is not described in the paper, is very
 straightforward.  It uses a recursive merge algorithm starting at the
 root node of the new tree and the root node of the old tree.
 
-1. The invariant is that the current node is matched by the corresonding
+1. The invariant is that the current node is matched by the corresponding
    node in the old tree.
 2. First, step through child nodes in the old tree.  Mark as deleted all
    nodes not being matched to the new tree.

--- a/regress/diff/diff.old.md
+++ b/regress/diff/diff.old.md
@@ -160,8 +160,8 @@ begins with a short sanitisation pass.
     4. If the no candidates were found, enqueue the node's children into
        the priority queue.
     5. A a candidate was selected, mark all of its subtree nodes as
-       matching the corresponding nodes in the old tree ("propogate
-       down"), then mark ancestor nodes similarly ("propogate up").
+       matching the corresponding nodes in the old tree ("propagate
+       down"), then mark ancestor nodes similarly ("propagate up").
        ([diff.c](https://github.com/kristapsdz/lowdown/blob/master/diff.c),
        `match_up()`, `match_down()`)
 
@@ -219,15 +219,15 @@ In the event of similar optimality, the node "closest" to the current
 node is chosen.  Proximity is defined by the node identifier, which is
 its prefix order in the parse tree.
 
-### "Propogate up"
+### "Propagate up"
 
-When propogating a match upward, the distance upward is bound depending
+When propagating a match upward, the distance upward is bound depending
 on the matched sub-tree as defined in the paper.  This makes it so that
 "small" similarities (such as text) don't erroneously match two larger
 sub-trees that are otherwise different.  Upward matches occur while the
 nodes' labels are the same, including attributes (e.g., link text).
 
-I did modify the algorithm to propogate upward "for free" through
+I did modify the algorithm to propagate upward "for free" through
 similar singleton nodes, even if it means going beyond the maximum
 number allowed by the sub-tree weight.
 
@@ -235,7 +235,7 @@ number allowed by the sub-tree weight.
 
 The [lowdown-diff(1)](https://kristaps.bsd.lv/lowdown/lowdown.1.html)
 algorithm has two optimisations, both lightly derived from the paper:
-top-down and bottom-up propogation.
+top-down and bottom-up propagation.
 
 #### Top-down
 
@@ -249,8 +249,8 @@ difference downward in the tree.
 
 #### Bottom-up
 
-In the bottom-up propogation, the weight of any given sub-tree is used
-to compute how high a match will propogate.  I extend the paper's
+In the bottom-up propagation, the weight of any given sub-tree is used
+to compute how high a match will propagate.  I extend the paper's
 version optimisation by looking at the cumulative weight of matching
 children.
 
@@ -269,7 +269,7 @@ The merging phase, which is not described in the paper, is very
 straightforward.  It uses a recursive merge algorithm starting at the
 root node of the new tree and the root node of the old tree.
 
-1. The invariant is that the current node is matched by the corresonding
+1. The invariant is that the current node is matched by the corresponding
    node in the old tree.
 2. First, step through child nodes in the old tree.  Mark as deleted all
    nodes not being matched to the new tree.

--- a/term.c
+++ b/term.c
@@ -490,7 +490,7 @@ rndr_buf_startline_prefixes(struct term *term,
 	 * The "sinner" value is temporary for only this function.
 	 * This allows us to set a temporary style mask that only
 	 * applies to the prefix data.
-	 * Otherwise "s" propogates to the subsequent line.
+	 * Otherwise "s" propagates to the subsequent line.
 	 */
 
 	rndr_node_style(s, n);

--- a/versions.xml
+++ b/versions.xml
@@ -116,7 +116,7 @@
 				I've described the problems in the <q>Hacking</q> section of the web site.
 			</p>
 			<p>
-				Disable the <q>semantic quotes</q> (where in HTML mode qoutes would be rendered as
+				Disable the <q>semantic quotes</q> (where in HTML mode quotes would be rendered as
 				<code>&lt;q&gt;</code>) and <q>underline as emphasis</q>, which rendered emphasis as an underline.
 				The underlines aren't easy in <b>-Tms</b> and <b>-Tman</b> and presentationally confusing (is it a link?) in
 				<b>-Thtml</b>.
@@ -545,7 +545,7 @@
 				terminal.  This is inspired by 
 				<a href="https://github.com/charmbracelet/glow">glow</a>.
 				This output is still experimental and the style may currently not be
-				overriden.
+				overridden.
 			</p>
 			<p>
 				Add missing documentation to <a
@@ -1005,7 +1005,7 @@
 			<p>
 				Introduce <b>-m</b> and <b>-M</b>, which allow metadata to be
 				provided on the command line.
-				Metadata keys are first looked for in <b>-m</b>, overriden by what's
+				Metadata keys are first looked for in <b>-m</b>, overridden by what's
 				in the document, and those overridden by what's in <b>-M</b>.
 			</p>
 			<p>


### PR DESCRIPTION
-  propogate    -> propagate (and -ing, -ion, etc.)
-  classses     -> classes
-  corresonding -> corresponding
-  fetaures     -> features
-  overriden    -> overridden
-  qoutes       -> quotes

Discovered through "spellintian".