### PR TITLE
Don't output a newline between `.SH` and heading text for `nroff`

### DIFF
--- a/regress/diff/metadata-add.man
+++ b/regress/diff/metadata-add.man
@@ -1,6 +1,5 @@
 .\" -*- mode: troff; coding: utf-8 -*-
 .TH "" "7" ""
-.SH
-section
+.SH section
 .LP
 body

--- a/regress/diff/metadata-remove.man
+++ b/regress/diff/metadata-remove.man
@@ -1,6 +1,5 @@
 .\" -*- mode: troff; coding: utf-8 -*-
 .TH "" "7" ""
-.SH
-section
+.SH section
 .LP
 body

--- a/regress/shift-heading-level-by-neg.man
+++ b/regress/shift-heading-level-by-neg.man
@@ -1,9 +1,7 @@
-.SH
-header 1
+.SH header 1
 .LP
 1
-.SH
-header 2
+.SH header 2
 .LP
 2
 .SS

--- a/regress/shift-heading-level-by-zero.man
+++ b/regress/shift-heading-level-by-zero.man
@@ -1,5 +1,4 @@
-.SH
-header 1
+.SH header 1
 .LP
 1
 .SS

--- a/regress/simple.man
+++ b/regress/simple.man
@@ -1,5 +1,4 @@
-.SH
-An h1 header
+.SH An h1 header
 .LP
 Paragraphs are separated by a blank line.
 .PP


### PR DESCRIPTION
On macOS, `makewhatis` fails to parse `NAME` headings in man pages if there's a newline between `.SH` and `NAME`. This is silly, but I can't exactly get them to update it:

```
$ /usr/libexec/makewhatis -v -o /tmp/whatis outputs/out/share/man | head
man directory outputs/out/share/man
  outputs/out/share/man/man5
        reading outputs/out/share/man/man5/nix.conf.5
        ignoring junk description ""
        reading outputs/out/share/man/man5/nix-profiles.5
        ignoring junk description ""
```

Through a circuitous sequence of events, this results in shell completions for the `man` command being broken in Fish for man pages generated with Lowdown:
https://git.lix.systems/lix-project/lix/issues/515

This patch, then, replaces the trailing newline after blocks with a trailing space for `.SH` blocks in `nroff` output.