### PR TITLE
Fix `iscntrl` on macOS

### DIFF
--- a/gemini.c
+++ b/gemini.c
@@ -180,7 +180,8 @@ rndr_escape(struct lowdown_buf *out, const char *buf, size_t sz)
 			if (!hbuf_putc(out, ' '))
 				return 0;
 			start = i + 1;
-		} else if (iscntrl((unsigned char)buf[i])) {
+		} else if ((unsigned char) buf[i] < 0x80 && iscntrl((unsigned char)buf[i])) {
+            fprintf(stderr, "this is a control character: %x %x\n", (unsigned char)buf[i], buf[i]);
 			if (!hbuf_put(out, buf + start, i - start))
 				return 0;
 			start = i + 1;

--- a/term.c
+++ b/term.c
@@ -187,7 +187,7 @@ rndr_escape(struct term *term, struct lowdown_buf *out,
 	/* Don't allow control characters through. */
 
 	for (i = 0; i < sz; i++)
-		if (iscntrl((unsigned char)buf[i])) {
+		if ((unsigned char)buf[i] < 0x80 && iscntrl((unsigned char)buf[i])) {
 			ret = rndr_mbswidth
 				(term, buf + start, i - start);
 			if (ret < 0)

--- a/tree.c
+++ b/tree.c
@@ -94,7 +94,7 @@ rndr_short(struct lowdown_buf *ob, const struct lowdown_buf *b)
 		} else if (b->data[i] == '\t') {
 			if (!HBUF_PUTSL(ob, "\\t"))
 				return 0;
-		} else if (iscntrl((unsigned char)b->data[i])) {
+		} else if ((unsigned char)b->data[i] < 0x80 && iscntrl((unsigned char)b->data[i])) {
 			if (!hbuf_putc(ob, '?'))
 				return 0;
 		} else {


### PR DESCRIPTION
Fix `iscntrl` on macOS by treating all bytes >=0x80 as not control characters. This produces INCORRECT results for codepoints U+0080 through U+009F.

This closes #139 and #137.

For correctness we should probably actually decode the UTF-8 to give proper results for U+0080 through U+009F, but that might require some rearchitecting. In the meantime, this makes the regression test suite pass on my machine.