### PR TITLE
Ignore `test-*.dSYM` directories for macOS configure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 Makefile.configure
 config.h
 config.log
+test-*.dSYM  # macOS only
 # object files
 *.[oa]
 *.so.*


### PR DESCRIPTION
`./configure` generates a bunch of these on macOS:

```
test-PATH_MAX.dSYM/
test-WAIT_ANY.dSYM/
test-__progname.dSYM/
test-arc4random.dSYM/
test-b64_ntop.dSYM/
test-crypt.dSYM/
test-err.dSYM/
test-fts.dSYM/
test-getprogname.dSYM/
test-lib_socket.dSYM/
test-memmem.dSYM/
test-memset_s.dSYM/
test-osbyteorder_h.dSYM/
test-readpassphrase.dSYM/
test-sandbox_init.dSYM/
test-strlcat.dSYM/
test-strlcpy.dSYM/
test-strndup.dSYM/
test-strnlen.dSYM/
test-strtonum.dSYM/
test-sys_queue.dSYM/
test-termios.dSYM/
```