### PR TITLE
default `loading="lazy"` on `<img>` output

### DIFF
--- a/html.c
+++ b/html.c
@@ -671,7 +671,7 @@ rndr_image(struct lowdown_buf *ob, const struct rndr_image *param,
 
 	/* Require an "alt", even if blank. */
 
-	if (!HBUF_PUTSL(ob, "<img src=\"") ||
+	if (!HBUF_PUTSL(ob, "<img loading=\"lazy\" src=\"") ||
 	    !escape_href(ob, &param->link, st) ||
 	    !HBUF_PUTSL(ob, "\" alt=\"") ||
 	    !escape_attr(ob, &param->alt) ||


### PR DESCRIPTION
This is a somewhat major performance feature for HTML rendering in practice. Although there are certainly cases where you want to eagerly load images (logos, headers), the significant majority use benefits from the lazy loading of images which are distributed throughout the document.     

There doesn't seem to be an existing mechanism for controlling this kind of attribute on tags, this PR just sets it as a default.

