### PR TITLE
WIP: Cygwin build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ uninstall_shared: uninstall_lib_common
 	rm -f $(LIBDIR)/$(LIB_SOVER) $(LIBDIR)/$(LIB_SO)
 
 install_shared: $(LIB_SO) install_lib_common
-	$(INSTALL_LIB) $(LIB_SOVER) $(DESTDIR)$(LIBDIR)
+	$(INSTALL_LIB) $(LIB_SOVER) $(IMPLIB) $(DESTDIR)$(LIBDIR)
 	( cd $(DESTDIR)$(LIBDIR) && ln -sf $(LIB_SOVER) $(LIB_SO) )
 
 uninstall_static: uninstall_lib_common


### PR DESCRIPTION
Here are some changes I'm working on to make it easier to do cygwin builds without patching the makefile.

With these changes I still need to use:

```
EXESUFFIX=.exe
LINKER_SOSUFFIX=dll
LIB_SO=cyglowdown.dll
IMPLIB=liblowdown.dll.a
LDFLAGS=-Wl,--out-implib,liblowdown.dll.a
```

I'm looking for feedback on how to implement these in a merge-able way.  It would be nice if `configure` handled it in some way, but I don't see any similar OS detection in there.