### PR TITLE
A first paragraph with an inline link was parsed as metadata and thus discarded.

### DIFF
--- a/document.c
+++ b/document.c
@@ -689,7 +689,7 @@ is_metadata_block_mmd(const char *data, size_t sz, int *is_yaml)
 
 	/*
 	 * Scan the line for link patterns.
-	 * Reject if we see '](' (inline link) or '://' (URL scheme).
+	 * Reject if we see '](' (inline link).
 	 */
 	for (size_t j = i ; j < sz; j++) {
 		if (data[j] == '\n')

--- a/regress/inline-link-before-blockquote.html
+++ b/regress/inline-link-before-blockquote.html
@@ -1,0 +1,4 @@
+<p>Paragraph with <a href="https://example.com">inline link</a> text.</p>
+<blockquote>
+<p>Blockquote line.</p>
+</blockquote>

--- a/regress/inline-link-before-blockquote.md
+++ b/regress/inline-link-before-blockquote.md
@@ -1,0 +1,3 @@
+Paragraph with [inline link](https://example.com) text.
+
+> Blockquote line.


### PR DESCRIPTION
The fix: Adding link detection to `is_metadata_block_mmd()` so that content containing inline an inline link of the form [text](url) gets rejected.