### PR TITLE
Wrap table cells to --term-columns in -Tterm output

### DIFF
--- a/regress/table-wrap-align.md
+++ b/regress/table-wrap-align.md
@@ -1,0 +1,3 @@
+| abc | defghi |
+:-: | -----------:
+This is a centered cell that has a very long line of text which should wrap | This is a right-aligned cell with enough text to force wrapping at the default seventy two column limit

--- a/regress/table-wrap-align.term
+++ b/regress/table-wrap-align.term
@@ -1,0 +1,6 @@
+                 abc              [93m│[0m                         defghi
+    [93m──────────────────────────────┼────────────────────────────────[0m
+    This is a centered cell that  [93m│[0m   This is a right-aligned cell
+    has a very long line of text  [93m│[0m      with enough text to force
+          which should wrap       [93m│[0m        wrapping at the default
+                                  [93m│[0m       seventy two column limit

--- a/regress/table-wrap-basic.md
+++ b/regress/table-wrap-basic.md
@@ -1,0 +1,4 @@
+| Name | Status | Description |
+|------|--------|-------------|
+| alpha | active | This is a very long description that should definitely exceed the default seventy two column width limit |
+| beta | pending | Another extremely verbose description that goes on and on and on past the column boundary |

--- a/regress/table-wrap-basic.term
+++ b/regress/table-wrap-basic.term
@@ -1,0 +1,8 @@
+    Name  [93m│[0m Status  [93m│[0m Description                                
+    [93m──────┼─────────┼─────────────────────────────────────────────[0m
+    alpha [93m│[0m active  [93m│[0m This is a very long description that should
+          [93m│[0m         [93m│[0m definitely exceed the default seventy two  
+          [93m│[0m         [93m│[0m column width limit                         
+    beta  [93m│[0m pending [93m│[0m Another extremely verbose description that 
+          [93m│[0m         [93m│[0m goes on and on and on past the column      
+          [93m│[0m         [93m│[0m boundary                                   

--- a/regress/table-wrap-blockquote.md
+++ b/regress/table-wrap-blockquote.md
@@ -1,0 +1,4 @@
+| abc | def |
+| --- | --- |
+| bar with lots of extra text that goes well past the column limit | baz also has extra text that exceeds width |
+> This blockquote follows a table that should wrap to see that the transition between wrapped table and blockquote works properly

--- a/regress/table-wrap-blockquote.term
+++ b/regress/table-wrap-blockquote.term
@@ -1,0 +1,9 @@
+    abc                           [93m│[0m def                           
+    [93m──────────────────────────────┼────────────────────────────────[0m
+    bar with lots of extra text   [93m│[0m baz also has extra text that  
+    that goes well past the       [93m│[0m exceeds width                 
+    column limit                  [93m│[0m                               
+    
+    [93m  │ [0mThis blockquote follows a table that should wrap to see that
+    [93m  │ [0mthe transition between wrapped table and blockquote works
+    [93m  │ [0mproperly

--- a/regress/table-wrap-equal.md
+++ b/regress/table-wrap-equal.md
@@ -1,0 +1,3 @@
+| Long Column A | Long Column B | Long Column C |
+|---|---|---|
+| This column has lots of text in it that will be quite long | Also lots of text here as well to make it equally wide | And more text here too for good measure to match the others |

--- a/regress/table-wrap-equal.term
+++ b/regress/table-wrap-equal.term
@@ -1,0 +1,6 @@
+    Long Column A      [93m│[0m Long Column B      [93m│[0m Long Column C      
+    [93m───────────────────┼────────────────────┼─────────────────────[0m
+    This column has    [93m│[0m Also lots of text  [93m│[0m And more text here 
+    lots of text in it [93m│[0m here as well to    [93m│[0m too for good       
+    that will be quite [93m│[0m make it equally    [93m│[0m measure to match   
+    long               [93m│[0m wide               [93m│[0m the others         

--- a/regress/table-wrap-escaped-pipe.md
+++ b/regress/table-wrap-escaped-pipe.md
@@ -1,0 +1,4 @@
+| f\|oo |
+| ------ |
+| b `\|` az with a lot of extra text added so that this single column table exceeds the seventy two column default width |
+| b **\|** im also with quite a bit of text that makes the content much wider than seventy two columns |

--- a/regress/table-wrap-escaped-pipe.term
+++ b/regress/table-wrap-escaped-pipe.term
@@ -1,0 +1,6 @@
+    f|oo                                                           
+    [93m────────────────────────────────────────────────────────────────[0m
+    b [1;94m\|[0m az with a lot of extra text added so that this single     
+    column table exceeds the seventy two column default width      
+    b [1m|[0m im also with quite a bit of text that makes the content    
+    much wider than seventy two columns                            

--- a/regress/table-wrap-extra-cells.md
+++ b/regress/table-wrap-extra-cells.md
@@ -1,0 +1,4 @@
+| abc | def |
+| --- | --- |
+| bar with a long cell that has plenty of text to exceed the default width |
+| bar | baz | boo with extra content that extends beyond the defined columns of this table to see what happens with wrapping |

--- a/regress/table-wrap-extra-cells.term
+++ b/regress/table-wrap-extra-cells.term
@@ -1,0 +1,5 @@
+    abc                                                      [93m│[0m def
+    [93m─────────────────────────────────────────────────────────┼─────[0m
+    bar with a long cell that has plenty of text to exceed   [93m│[0m    
+    the default width                                        [93m│[0m    
+    bar                                                      [93m│[0m baz

--- a/regress/table-wrap-footnote-in-table.md
+++ b/regress/table-wrap-footnote-in-table.md
@@ -1,0 +1,19 @@
+first[^pt0]
+
+| Name | Description |
+| --- | --- |
+| item[^pt1][^pt2] | This is a very long description that should exceed the seventy two column default width and trigger wrapping |
+
+Now[^pt3]
+
+[^pt0]: one
+
+[^pt1]: two
+
+[^pt2]: three
+
+    hello
+
+    - world
+
+[^pt3]: four

--- a/regress/table-wrap-footnote-in-table.term
+++ b/regress/table-wrap-footnote-in-table.term
@@ -1,0 +1,20 @@
+    first[1;93m[1][0m
+    
+    Name       [93m│[0m Description                                      
+    [93m───────────┼───────────────────────────────────────────────────[0m
+    item[1;93m[2][0m[1;93m[3][0m [93m│[0m This is a very long description that should      
+               [93m│[0m exceed the seventy two column default width and  
+               [93m│[0m trigger wrapping                                 
+    
+    Now[1;93m[4][0m
+
+    [37m────────────────────────────────────────────────────────────────────[0m
+
+    [92m 1. [0mone
+    [92m 2. [0mtwo
+    [92m 3. [0mthree
+    [92m    [0m
+    [92m    [0mhello
+    [92m    [0m
+    [92m    [0m[93m  · [0mworld 
+    [92m 4. [0mfour

--- a/regress/table-wrap-footnotes.md
+++ b/regress/table-wrap-footnotes.md
@@ -1,0 +1,26 @@
+a[^1]
+a[^2]
+a[^3]
+a[^4]
+a[^5]
+a[^6]
+a[^7]
+a[^8]
+
+| Officer | Rank | Posting |
+| ------: | ---- | ------- |
+| Jean-Luc Picard[^9] | Captain | Commanding officer of the USS Enterprise NCC-1701-D and later the Enterprise-E |
+| Worf[^10] | Lieutenant Commander | Chief of security and tactical officer aboard the Enterprise and later Deep Space Nine |
+| Data[^11] | Lieutenant Commander | Chief operations officer of the USS Enterprise and a sentient android created by Doctor Noonian Soong |
+
+[^1]: foo
+[^2]: foo
+[^3]: foo
+[^4]: foo
+[^5]: foo
+[^6]: foo
+[^7]: foo
+[^8]: foo
+[^9]: foo
+[^10]: foo
+[^11]: foo

--- a/regress/table-wrap-footnotes.term
+++ b/regress/table-wrap-footnotes.term
@@ -1,0 +1,36 @@
+    a[1;93m[1][0m a[1;93m[2][0m a[1;93m[3][0m a[1;93m[4][0m a[1;93m[5][0m a[1;93m[6][0m a[1;93m[7][0m a[1;93m[8][0m
+    
+               Officer [93m│[0m Rank               [93m│[0m Posting            
+    [93m───────────────────┼────────────────────┼─────────────────────[0m
+    Jean-Luc Picard[1;93m[9][0m [93m│[0m Captain            [93m│[0m Commanding officer 
+                       [93m│[0m                    [93m│[0m of the USS         
+                       [93m│[0m                    [93m│[0m Enterprise         
+                       [93m│[0m                    [93m│[0m NCC-1701-D and     
+                       [93m│[0m                    [93m│[0m later the          
+                       [93m│[0m                    [93m│[0m Enterprise-E       
+              Worf[1;93m[10][0m [93m│[0m Lieutenant         [93m│[0m Chief of security  
+                       [93m│[0m Commander          [93m│[0m and tactical       
+                       [93m│[0m                    [93m│[0m officer aboard the 
+                       [93m│[0m                    [93m│[0m Enterprise and     
+                       [93m│[0m                    [93m│[0m later Deep Space   
+                       [93m│[0m                    [93m│[0m Nine               
+              Data[1;93m[11][0m [93m│[0m Lieutenant         [93m│[0m Chief operations   
+                       [93m│[0m Commander          [93m│[0m officer of the USS 
+                       [93m│[0m                    [93m│[0m Enterprise and a   
+                       [93m│[0m                    [93m│[0m sentient android   
+                       [93m│[0m                    [93m│[0m created by Doctor  
+                       [93m│[0m                    [93m│[0m Noonian Soong      
+
+    [37m────────────────────────────────────────────────────────────────────[0m
+
+    [92m 1. [0mfoo
+    [92m 2. [0mfoo
+    [92m 3. [0mfoo
+    [92m 4. [0mfoo
+    [92m 5. [0mfoo
+    [92m 6. [0mfoo
+    [92m 7. [0mfoo
+    [92m 8. [0mfoo
+    [92m 9. [0mfoo
+    [92m10. [0mfoo
+    [92m11. [0mfoo

--- a/regress/table-wrap-links.md
+++ b/regress/table-wrap-links.md
@@ -1,0 +1,4 @@
+| Name | URL | Description |
+| --- | --- | --- |
+| Example Site | [A very long link text](https://example.com/path/to/resource) | This is a detailed description of the example site which should wrap |
+| Another Site | https://another-example.com/very/long/path/to/demonstrate/wrapping | Also has a description that exceeds the seventy two column width limit |

--- a/regress/table-wrap-links.term
+++ b/regress/table-wrap-links.term
@@ -1,0 +1,10 @@
+    Name         [93m│[0m URL                   [93m│[0m Description           
+    [93m─────────────┼───────────────────────┼────────────────────────[0m
+    Example Site [93m│[0m ]8;;https://example.com/path/to/resource\[1;93mA very long link text[0m]8;;\ [93m│[0m This is a detailed    
+                 [93m│[0m ]8;;https://example.com/path/to/resource\[4;32mhttps://example.com/p[0m [93m│[0m description of the    
+                 [93m│[0m [4;32math/to/resource[0m]8;;\       [93m│[0m example site which    
+                 [93m│[0m                       [93m│[0m should wrap           
+    Another Site [93m│[0m ]8;;https://another-example.com/very/long/path/to/demonstrate/wrapping\[4;32mhttps://another-examp[0m [93m│[0m Also has a description
+                 [93m│[0m [4;32mle.com/very/long/path[0m [93m│[0m that exceeds the      
+                 [93m│[0m [4;32m/to/demonstrate/wrapp[0m [93m│[0m seventy two column    
+                 [93m│[0m [4;32ming[0m]8;;\                   [93m│[0m width limit           

--- a/regress/table-wrap-mixed-styles.md
+++ b/regress/table-wrap-mixed-styles.md
@@ -1,0 +1,4 @@
+| Name | Status | Description |
+|------|--------|-------------|
+| **alpha** | *active* | This _very important_ description has **bold text** and *italic text* that should wrap properly across multiple lines to stay within width |
+| gamma | done | Plain text mixed with **bold** and *italic* and ~~strikethrough~~ in a cell that also exceeds the default seventy two column limit |

--- a/regress/table-wrap-mixed-styles.term
+++ b/regress/table-wrap-mixed-styles.term
@@ -1,0 +1,9 @@
+    Name  [93m│[0m Status [93m│[0m Description                                 
+    [93m──────┼────────┼──────────────────────────────────────────────[0m
+    [1malpha[0m [93m│[0m [3mactive[0m [93m│[0m This [3mvery important[0m description has [1mbold[0m    
+          [93m│[0m        [93m│[0m [1mtext[0m and [3mitalic text[0m that should wrap       
+          [93m│[0m        [93m│[0m properly across multiple lines to stay      
+          [93m│[0m        [93m│[0m within width                                
+    gamma [93m│[0m done   [93m│[0m Plain text mixed with [1mbold[0m and [3mitalic[0m and   
+          [93m│[0m        [93m│[0m [9mstrikethrough[0m in a cell that also exceeds   
+          [93m│[0m        [93m│[0m the default seventy two column limit        

--- a/regress/table-wrap-multiline.md
+++ b/regress/table-wrap-multiline.md
@@ -1,0 +1,6 @@
+| Field | Required | Description |
+| --- | --- | --- |
+| `disable-model-invocation` | No | Set to true to prevent automatic loading of this skill by the system. |
+|  |  | Also prevents the skill from being preloaded into subagents and other contexts. |
+| `user-invocable` | No | Set to false to hide from the menu so users cannot invoke it directly. |
+|  |  | Use for background knowledge users should not invoke directly as a command. |

--- a/regress/table-wrap-multiline.term
+++ b/regress/table-wrap-multiline.term
@@ -1,0 +1,18 @@
+    Field                   [93m│[0m Required [93m│[0m Description             
+    [93m────────────────────────┼──────────┼──────────────────────────[0m
+    [1;94mdisable-model-invocatio[0m [93m│[0m No       [93m│[0m Set to true to prevent  
+    [1;94mn[0m                       [93m│[0m          [93m│[0m automatic loading of    
+                            [93m│[0m          [93m│[0m this skill by the       
+                            [93m│[0m          [93m│[0m system.                 
+                            [93m│[0m          [93m│[0m Also prevents the skill 
+                            [93m│[0m          [93m│[0m from being preloaded    
+                            [93m│[0m          [93m│[0m into subagents and other
+                            [93m│[0m          [93m│[0m contexts.               
+    [1;94muser-invocable[0m          [93m│[0m No       [93m│[0m Set to false to hide    
+                            [93m│[0m          [93m│[0m from the menu so users  
+                            [93m│[0m          [93m│[0m cannot invoke it        
+                            [93m│[0m          [93m│[0m directly.               
+                            [93m│[0m          [93m│[0m Use for background      
+                            [93m│[0m          [93m│[0m knowledge users should  
+                            [93m│[0m          [93m│[0m not invoke directly as a
+                            [93m│[0m          [93m│[0m command.                

--- a/regress/table-wrap-single-col.md
+++ b/regress/table-wrap-single-col.md
@@ -1,0 +1,3 @@
+| Only Column |
+|---|
+| This text in a single column table is extremely long and verbose and should exceed the seventy two column default pipe width limit easily |

--- a/regress/table-wrap-single-col.term
+++ b/regress/table-wrap-single-col.term
@@ -1,0 +1,5 @@
+    Only Column                                                    
+    [93m────────────────────────────────────────────────────────────────[0m
+    This text in a single column table is extremely long and       
+    verbose and should exceed the seventy two column default pipe  
+    width limit easily                                             

--- a/regress/table-wrap-styled.md
+++ b/regress/table-wrap-styled.md
@@ -1,0 +1,3 @@
+| Name | Note |
+|------|------|
+| **bold** | *italic text that is very long and will definitely need to wrap across multiple lines in order to fit within seventy two columns* |

--- a/regress/table-wrap-styled.term
+++ b/regress/table-wrap-styled.term
@@ -1,0 +1,5 @@
+    Name [93m│[0m Note                                                   
+    [93m─────┼─────────────────────────────────────────────────────────[0m
+    [1mbold[0m [93m│[0m [3mitalic text that is very long and will definitely need[0m 
+         [93m│[0m [3mto wrap across multiple lines in order to fit within[0m   
+         [93m│[0m [3mseventy two columns[0m                                    

--- a/regress/table-wrap-styles-aligned.md
+++ b/regress/table-wrap-styles-aligned.md
@@ -1,0 +1,11 @@
+| Header 1 | Header 2 | Header 3 | Header 4 |
+|----------|----------|----------|----------|
+| ***Bold italic content that is long enough to force this table to wrap*** | Content 2 | Content 3 | Content 4 |
+
+| Header 1 | Header 2 | Header 3 | Header 4 |
+|----------|----------|----------|----------|
+| *Italic cell one with enough text to exceed the seventy two column limit* | **Bold cell two also long enough to wrap across lines easily** | Content 3 | Content 4 |
+
+| Header 1 | Header 2 | Header 3 | Header 4 |
+|----------|----------|----------|----------|
+| Plain text that is long enough to wrap | *styled text also long enough to wrap across the line boundary* | **bold text in third column** | Content 4 |

--- a/regress/table-wrap-styles-aligned.term
+++ b/regress/table-wrap-styles-aligned.term
@@ -1,0 +1,21 @@
+    Header 1                 [93m│[0m Header 2  [93m│[0m Header 3  [93m│[0m Header 4 
+    [93m─────────────────────────┼───────────┼───────────┼───────────[0m
+    [1;3mBold italic content that[0m [93m│[0m Content 2 [93m│[0m Content 3 [93m│[0m Content 4
+    [1;3mis long enough to force[0m  [93m│[0m           [93m│[0m           [93m│[0m          
+    [1;3mthis table to wrap[0m       [93m│[0m           [93m│[0m           [93m│[0m          
+    
+    Header 1         [93m│[0m Header 2          [93m│[0m Header 3  [93m│[0m Header 4 
+    [93m─────────────────┼───────────────────┼───────────┼───────────[0m
+    [3mItalic cell one[0m  [93m│[0m [1mBold cell two[0m     [93m│[0m Content 3 [93m│[0m Content 4
+    [3mwith enough text[0m [93m│[0m [1malso long enough[0m  [93m│[0m           [93m│[0m          
+    [3mto exceed the[0m    [93m│[0m [1mto wrap across[0m    [93m│[0m           [93m│[0m          
+    [3mseventy two[0m      [93m│[0m [1mlines easily[0m      [93m│[0m           [93m│[0m          
+    [3mcolumn limit[0m     [93m│[0m                   [93m│[0m           [93m│[0m          
+    
+    Header 1       [93m│[0m Header 2       [93m│[0m Header 3       [93m│[0m Header 4 
+    [93m───────────────┼────────────────┼────────────────┼───────────[0m
+    Plain text     [93m│[0m [3mstyled text[0m    [93m│[0m [1mbold text in[0m   [93m│[0m Content 4
+    that is long   [93m│[0m [3malso long[0m      [93m│[0m [1mthird column[0m   [93m│[0m          
+    enough to wrap [93m│[0m [3menough to wrap[0m [93m│[0m                [93m│[0m          
+                   [93m│[0m [3macross the[0m     [93m│[0m                [93m│[0m          
+                   [93m│[0m [3mline boundary[0m  [93m│[0m                [93m│[0m          

--- a/src/format/term/term.c
+++ b/src/format/term/term.c
@@ -1316,14 +1316,21 @@ wrapline_emit(struct wrapline **out, size_t *nlines, size_t *cap,
  * without consuming visible width.  Tracks SGR state across
  * line breaks for proper style open/close on continuation lines.
  *
+ * When nobrk is zero (default), words wider than maxcols are
+ * force-broken mid-character to keep every line within the
+ * limit.  When nobrk is non-zero, long words are kept whole
+ * and the resulting line may exceed maxcols; the caller is
+ * responsible for truncating the display.
+ *
  * Allocates *lines (caller must free) and sets *nlines.
  * Returns zero on failure (memory), non-zero on success.
  */
 static int
 rndr_buf_ansi_wrap(struct term *term, const struct lowdown_buf *buf,
-	size_t maxcols, struct wrapline **lines, size_t *nlines)
+	size_t maxcols, int nobrk,
+	struct wrapline **lines, size_t *nlines)
 {
-	size_t		 i = 0, vc = 0;
+	size_t		 i = 0, vc = 0, prev_i;
 	size_t		 line_start = 0;
 	size_t		 last_break_byte = 0, last_break_vc = 0;
 	int		 have_break = 0;
@@ -1350,12 +1357,6 @@ rndr_buf_ansi_wrap(struct term *term, const struct lowdown_buf *buf,
 			last_break_vc = vc;
 			have_break = 1;
 			if (vc > maxcols) {
-				/*
-				 * Emit line with the SGR that was
-				 * active at its start, then advance
-				 * the running SGR state past this
-				 * line for the next one.
-				 */
 				memcpy(line_sgr, sgr, sgrlen);
 				line_sgrlen = sgrlen;
 				sgr_track(buf->data, line_start,
@@ -1373,6 +1374,7 @@ rndr_buf_ansi_wrap(struct term *term, const struct lowdown_buf *buf,
 			continue;
 		}
 
+		prev_i = i;
 		cw = ansi_chwidth(term, buf->data, buf->size, &i);
 		if (cw < 0)
 			goto fail;
@@ -1394,6 +1396,25 @@ rndr_buf_ansi_wrap(struct term *term, const struct lowdown_buf *buf,
 				return 0;
 			line_start = last_break_byte;
 			vc -= last_break_vc;
+			have_break = 0;
+		} else if (!nobrk && cw > 0) {
+			/*
+			 * Force mid-word break: emit up to
+			 * just before the character that
+			 * overflowed, start a new line there.
+			 */
+			memcpy(line_sgr, sgr, sgrlen);
+			line_sgrlen = sgrlen;
+			sgr_track(buf->data, line_start,
+			    prev_i, sgr, &sgrlen);
+			if (!wrapline_emit(&out, nlines, &cap,
+			    line_start, prev_i,
+			    vc - (size_t)cw,
+			    line_sgr, line_sgrlen,
+			    buf->data, buf->size))
+				return 0;
+			line_start = prev_i;
+			vc = (size_t)cw;
 			have_break = 0;
 		}
 	}
@@ -1422,6 +1443,42 @@ rndr_buf_ansi_wrap(struct term *term, const struct lowdown_buf *buf,
 fail:
 	free(out);
 	return 0;
+}
+
+/*
+ * Emit at most maxvc visible columns from buf[start..start+len).
+ * ANSI escapes are passed through without counting toward width.
+ * Returns the number of bytes emitted, or -1 on failure.
+ */
+static ssize_t
+hbuf_put_truncated(struct term *term, struct lowdown_buf *ob,
+	const char *buf, size_t start, size_t len, size_t maxvc)
+{
+	size_t	i = start, end = start + len, emitted = 0;
+	size_t	vc = 0;
+
+	while (i < end && vc < maxvc) {
+		size_t ni = ansi_skip(buf, end, i);
+		if (ni != i) {
+			if (!hbuf_put(ob, buf + i, ni - i))
+				return -1;
+			emitted += ni - i;
+			i = ni;
+			continue;
+		}
+		size_t prev = i;
+		ssize_t cw = ansi_chwidth(term, buf, end, &i);
+		if (cw < 0)
+			return -1;
+		if (vc + (size_t)cw > maxvc)
+			break;
+		if (!hbuf_put(ob, buf + prev, i - prev))
+			return -1;
+		emitted += i - prev;
+		vc += (size_t)cw;
+	}
+
+	return (ssize_t)emitted;
 }
 
 /*
@@ -1542,6 +1599,7 @@ rndr_table(struct lowdown_buf *ob, struct term *st,
 			widths[widest]--;
 			total--;
 		}
+
 	}
 
 	/*
@@ -1601,8 +1659,9 @@ rndr_table(struct lowdown_buf *ob, struct term *st,
 				st->width = maxcol;
 
 				if (!rndr_buf_ansi_wrap(st, cellbufs[i],
-				    widths[i] - 1, &cellwrap[i],
-				    &cellnlines[i]))
+				    widths[i] - 1,
+				    st->opts & LOWDOWN_TERM_NOBRK,
+				    &cellwrap[i], &cellnlines[i]))
 					goto out2;
 				if (cellnlines[i] > maxlines)
 					maxlines = cellnlines[i];
@@ -1635,9 +1694,13 @@ rndr_table(struct lowdown_buf *ob, struct term *st,
 							break;
 						}
 
-					pad = (wl != NULL) ?
-					    widths[i] - 1 - wl->viscols :
-					    widths[i] - 1;
+					if (wl != NULL &&
+				    wl->viscols <= widths[i] - 1)
+					pad = widths[i] - 1 - wl->viscols;
+				else if (wl != NULL)
+					pad = 0;
+				else
+					pad = widths[i] - 1;
 
 					/* Right-align pre-pad. */
 
@@ -1659,19 +1722,32 @@ rndr_table(struct lowdown_buf *ob, struct term *st,
 					/* Cell content for this line. */
 
 					if (wl != NULL && wl->len > 0) {
-						/*
-						 * Re-open style on
-						 * continuation lines.
-						 */
 						if (j > 0 && wl->sgrlen > 0)
 							if (!hbuf_put(rowtmp,
 							    wl->sgr,
 							    wl->sgrlen))
 								goto out2;
-						if (!hbuf_put(rowtmp,
-						    cellbufs[i]->data +
-						    wl->start, wl->len))
-							goto out2;
+
+						/*
+						 * Truncate if the line
+						 * overflows its column.
+						 */
+						if (wl->viscols >
+						    widths[i] - 1) {
+							if (hbuf_put_truncated(
+							    st, rowtmp,
+							    cellbufs[i]->data,
+							    wl->start, wl->len,
+							    widths[i] - 1) < 0)
+								goto out2;
+						} else {
+							if (!hbuf_put(rowtmp,
+							    cellbufs[i]->data +
+							    wl->start,
+							    wl->len))
+								goto out2;
+						}
+
 						/*
 						 * Close style if this line
 						 * has unclosed styles.

--- a/src/format/term/term.c
+++ b/src/format/term/term.c
@@ -1148,6 +1148,282 @@ rndr_stackpos_init(struct term *st, const struct lowdown_node *n)
 	return 1;
 }
 
+/* A single wrapped line from ANSI-aware word wrapping. */
+struct wrapline {
+	size_t	 start;		/* byte offset into source buf */
+	size_t	 len;		/* byte length */
+	size_t	 viscols;	/* visible column count */
+	char	 sgr[32];	/* active SGR at line start (e.g. "\033[3m") */
+	size_t	 sgrlen;	/* length of sgr, 0 if none */
+	int	 styled;	/* nonzero if line has unclosed styles */
+};
+
+/*
+ * Advance past one ANSI escape sequence starting at buf[i].
+ * Returns the new index past the sequence, or i if not an escape.
+ */
+static size_t
+ansi_skip(const char *buf, size_t sz, size_t i)
+{
+	if (i + 1 >= sz || buf[i] != '\033')
+		return i;
+	/* SGR: \033[...m */
+	if (buf[i + 1] == '[') {
+		i += 2;
+		while (i < sz && buf[i] != 'm')
+			i++;
+		if (i < sz)
+			i++;
+		return i;
+	}
+	/* OSC: \033]...ST (\033\\) */
+	if (buf[i + 1] == ']') {
+		i += 2;
+		while (i + 1 < sz &&
+		    !(buf[i] == '\033' && buf[i + 1] == '\\'))
+			i++;
+		if (i + 1 < sz)
+			i += 2;
+		return i;
+	}
+	return i;
+}
+
+/*
+ * Measure the visible column width of one character at buf[i],
+ * advancing i past it.  ANSI escapes contribute 0 visible width.
+ * Returns <0 on memory failure, >=0 visible columns.
+ */
+static ssize_t
+ansi_chwidth(struct term *term, const char *buf, size_t sz, size_t *i)
+{
+	size_t	ni;
+
+	/* ANSI escape: 0 visible width. */
+	ni = ansi_skip(buf, sz, *i);
+	if (ni != *i) {
+		*i = ni;
+		return 0;
+	}
+
+	/* UTF-8 multi-byte. */
+	if ((unsigned char)buf[*i] >= 0x80) {
+		size_t start = *i;
+		(*i)++;
+		while (*i < sz &&
+		    ((unsigned char)buf[*i] & 0xC0) == 0x80)
+			(*i)++;
+		return rndr_mbswidth(term, buf + start, *i - start);
+	}
+
+	/* ASCII. */
+	(*i)++;
+	return 1;
+}
+
+/*
+ * Track SGR state: record the last style-setting SGR sequence.
+ * Reset (\033[0m) clears the state.  Any other SGR replaces it.
+ */
+static void
+sgr_track(const char *buf, size_t start, size_t end,
+	char *sgr, size_t *sgrlen)
+{
+	size_t	i = start;
+
+	while (i < end) {
+		if (buf[i] != '\033' || i + 1 >= end) {
+			i++;
+			continue;
+		}
+		if (buf[i + 1] == '[') {
+			size_t seq_start = i;
+			i += 2;
+			while (i < end && buf[i] != 'm')
+				i++;
+			if (i < end)
+				i++;
+			/* Check if this is a reset (\033[0m). */
+			if (i - seq_start == 4 &&
+			    buf[seq_start + 2] == '0') {
+				*sgrlen = 0;
+			} else {
+				size_t len = i - seq_start;
+				if (len < 32) {
+					memcpy(sgr, buf + seq_start, len);
+					*sgrlen = len;
+				}
+			}
+		} else if (buf[i + 1] == ']') {
+			/* Skip OSC sequences. */
+			i += 2;
+			while (i + 1 < end &&
+			    !(buf[i] == '\033' && buf[i + 1] == '\\'))
+				i++;
+			if (i + 1 < end)
+				i += 2;
+		} else {
+			i++;
+		}
+	}
+}
+
+/*
+ * Emit a wrapline: grow the output array if needed.
+ * Copies the current SGR state into the new line.
+ * Returns zero on failure (memory), non-zero on success.
+ */
+static int
+wrapline_emit(struct wrapline **out, size_t *nlines, size_t *cap,
+	size_t line_start, size_t line_end, size_t viscols,
+	const char *sgr, size_t sgrlen,
+	const char *buf, size_t bufsz)
+{
+	struct wrapline	*wl;
+
+	if (*nlines >= *cap) {
+		*cap *= 2;
+		*out = reallocarray(*out, *cap, sizeof(struct wrapline));
+		if (*out == NULL)
+			return 0;
+	}
+
+	wl = &(*out)[*nlines];
+	wl->start = line_start;
+	wl->len = line_end - line_start;
+	wl->viscols = viscols;
+
+	/* SGR state active at the start of this line. */
+	memcpy(wl->sgr, sgr, sgrlen);
+	wl->sgrlen = sgrlen;
+
+	/* Check if this line has unclosed styles. */
+	{
+		char end_sgr[32];
+		size_t end_sgrlen = sgrlen;
+		memcpy(end_sgr, sgr, sgrlen);
+		sgr_track(buf, line_start, line_end, end_sgr, &end_sgrlen);
+		wl->styled = (end_sgrlen > 0);
+	}
+
+	(*nlines)++;
+	return 1;
+}
+
+/*
+ * Word-wrap buf into lines of at most maxcols visible columns.
+ * Breaks at whitespace boundaries.  ANSI escapes pass through
+ * without consuming visible width.  Tracks SGR state across
+ * line breaks for proper style open/close on continuation lines.
+ *
+ * Allocates *lines (caller must free) and sets *nlines.
+ * Returns zero on failure (memory), non-zero on success.
+ */
+static int
+rndr_buf_ansi_wrap(struct term *term, const struct lowdown_buf *buf,
+	size_t maxcols, struct wrapline **lines, size_t *nlines)
+{
+	size_t		 i = 0, vc = 0;
+	size_t		 line_start = 0;
+	size_t		 last_break_byte = 0, last_break_vc = 0;
+	int		 have_break = 0;
+	size_t		 cap = 4;
+	struct wrapline	*out;
+	ssize_t		 cw;
+	char		 sgr[32];
+	size_t		 sgrlen = 0;
+	char		 line_sgr[32];
+	size_t		 line_sgrlen = 0;
+
+	*lines = NULL;
+	*nlines = 0;
+
+	out = calloc(cap, sizeof(struct wrapline));
+	if (out == NULL)
+		return 0;
+
+	while (i < buf->size) {
+		if (buf->data[i] == ' ') {
+			i++;
+			vc++;
+			last_break_byte = i;
+			last_break_vc = vc;
+			have_break = 1;
+			if (vc > maxcols) {
+				/*
+				 * Emit line with the SGR that was
+				 * active at its start, then advance
+				 * the running SGR state past this
+				 * line for the next one.
+				 */
+				memcpy(line_sgr, sgr, sgrlen);
+				line_sgrlen = sgrlen;
+				sgr_track(buf->data, line_start,
+				    last_break_byte, sgr, &sgrlen);
+				if (!wrapline_emit(&out, nlines, &cap,
+				    line_start, last_break_byte - 1,
+				    last_break_vc - 1,
+				    line_sgr, line_sgrlen,
+				    buf->data, buf->size))
+					return 0;
+				line_start = last_break_byte;
+				vc -= last_break_vc;
+				have_break = 0;
+			}
+			continue;
+		}
+
+		cw = ansi_chwidth(term, buf->data, buf->size, &i);
+		if (cw < 0)
+			goto fail;
+		vc += (size_t)cw;
+
+		if (vc <= maxcols)
+			continue;
+
+		if (have_break) {
+			memcpy(line_sgr, sgr, sgrlen);
+			line_sgrlen = sgrlen;
+			sgr_track(buf->data, line_start,
+			    last_break_byte, sgr, &sgrlen);
+			if (!wrapline_emit(&out, nlines, &cap,
+			    line_start, last_break_byte - 1,
+			    last_break_vc - 1,
+			    line_sgr, line_sgrlen,
+			    buf->data, buf->size))
+				return 0;
+			line_start = last_break_byte;
+			vc -= last_break_vc;
+			have_break = 0;
+		}
+	}
+
+	/* Final line. */
+	if (i > line_start) {
+		if (!wrapline_emit(&out, nlines, &cap,
+		    line_start, i, vc,
+		    sgr, sgrlen,
+		    buf->data, buf->size))
+			return 0;
+	}
+
+	/* Ensure at least one line for empty cells. */
+	if (*nlines == 0) {
+		out[0].start = 0;
+		out[0].len = 0;
+		out[0].viscols = 0;
+		out[0].sgrlen = 0;
+		out[0].styled = 0;
+		*nlines = 1;
+	}
+
+	*lines = out;
+	return 1;
+fail:
+	free(out);
+	return 0;
+}
+
 /*
  * Return zero on failure (memory), non-zero on success.
  */
@@ -1224,16 +1500,92 @@ rndr_table(struct lowdown_buf *ob, struct term *st,
 	assert(st->footoff);
 	st->footoff = 0;
 
-	/* Now actually print, row-by-row into the output. */
+	/*
+	 * Clamp column widths to fit within st->width.
+	 * Separator overhead: " │ " = 3 visible cols per boundary.
+	 */
+
+	if (st->width != SIZE_MAX) {
+		size_t ncols, sep_overhead, total, avail;
+
+		ncols = n->rndr_table.columns;
+		sep_overhead = (ncols > 1) ? (ncols - 1) * 3 : 0;
+		avail = st->width - st->hmargin - st->hpadding;
+		if (avail > sep_overhead + ncols)
+			avail -= sep_overhead + ncols;
+		else
+			avail = ncols;
+
+		/*
+		 * widths[i] includes a +1 offset from the
+		 * measurement pass, so subtract ncols to get
+		 * the actual content total.
+		 */
+
+		total = 0;
+		for (i = 0; i < ncols; i++)
+			total += widths[i] - 1;
+
+		/*
+		 * Shrink the widest column by one, repeatedly,
+		 * until the total fits.  This preserves short
+		 * columns and only penalises the widest ones.
+		 */
+
+		while (total > avail) {
+			size_t widest = 0;
+			for (i = 1; i < ncols; i++)
+				if (widths[i] > widths[widest])
+					widest = i;
+			if (widths[widest] <= 2)
+				break;
+			widths[widest]--;
+			total--;
+		}
+	}
+
+	/*
+	 * Now actually print, row-by-row into the output.
+	 * Each cell is rendered, word-wrapped to its column width,
+	 * then rows are assembled line-by-line across all cells.
+	 */
+
+	{
+	size_t			 ncols = n->rndr_table.columns;
+	struct lowdown_buf	**cellbufs = NULL;
+	struct wrapline		**cellwrap = NULL;
+	size_t			*cellnlines = NULL;
+
+	cellbufs = calloc(ncols, sizeof(struct lowdown_buf *));
+	cellwrap = calloc(ncols, sizeof(struct wrapline *));
+	cellnlines = calloc(ncols, sizeof(size_t));
+	if (cellbufs == NULL || cellwrap == NULL || cellnlines == NULL)
+		goto out2;
+
+	for (i = 0; i < ncols; i++) {
+		cellbufs[i] = hbuf_new(128);
+		if (cellbufs[i] == NULL)
+			goto out2;
+	}
 
 	TAILQ_FOREACH(top, &n->children, entries) {
 		assert(top->type == LOWDOWN_TABLE_HEADER ||
 			top->type == LOWDOWN_TABLE_BODY);
 		TAILQ_FOREACH(row, &top->children, entries) {
-			hbuf_truncate(rowtmp);
+			size_t	maxlines = 0;
+
+			/* Render each cell and word-wrap it. */
+
+			for (i = 0; i < ncols; i++) {
+				hbuf_truncate(cellbufs[i]);
+				cellwrap[i] = NULL;
+				cellnlines[i] = 0;
+			}
+
 			TAILQ_FOREACH(cell, &row->children, entries) {
 				i = cell->rndr_table_cell.col;
-				hbuf_truncate(celltmp);
+				hbuf_truncate(cellbufs[i]);
+
 				maxcol = st->width;
 				last_blank = st->last_blank;
 				col = st->col;
@@ -1241,131 +1593,200 @@ rndr_table(struct lowdown_buf *ob, struct term *st,
 				st->last_blank = 0;
 				st->width = SIZE_MAX;
 				st->col = 1;
-				if (!rndr(celltmp, st, cell))
-					goto out;
-				assert(widths[i] >= st->col);
-				sz = widths[i] - st->col;
-
-				/*
-				 * Alignment is either beginning,
-				 * ending, or splitting the remaining
-				 * spaces around the word.
-				 * Be careful about uneven splitting in
-				 * the case of centre.
-				 */
-
-				flags = cell->rndr_table_cell.flags &
-					HTBL_FL_ALIGNMASK;
-				if (flags == HTBL_FL_ALIGN_RIGHT)
-					for (j = 0; j < sz; j++)
-						if (!HBUF_PUTSL(rowtmp, " "))
-							goto out;
-				if (flags == HTBL_FL_ALIGN_CENTER)
-					for (j = 0; j < sz / 2; j++)
-						if (!HBUF_PUTSL(rowtmp, " "))
-							goto out;
-				if (!hbuf_putb(rowtmp, celltmp))
-					goto out;
-				if (flags == 0 ||
-				    flags == HTBL_FL_ALIGN_LEFT)
-					for (j = 0; j < sz; j++)
-						if (!HBUF_PUTSL(rowtmp, " "))
-							goto out;
-				if (flags == HTBL_FL_ALIGN_CENTER) {
-					sz = (sz % 2) ?
-						(sz / 2) + 1 : (sz / 2);
-					for (j = 0; j < sz; j++)
-						if (!HBUF_PUTSL(rowtmp, " "))
-							goto out;
-				}
+				if (!rndr(cellbufs[i], st, cell))
+					goto out2;
 
 				st->last_blank = last_blank;
 				st->col = col;
 				st->width = maxcol;
 
-				if (TAILQ_NEXT(cell, entries) == NULL)
-					continue;
-
-				if (!HBUF_PUTSL(rowtmp, " ") ||
-				    !rndr_buf_style(st, rowtmp, &sty_tbl) ||
-				    !hbuf_puts(rowtmp, ifx_tbl_col) ||
-				    !rndr_buf_unstyle(st, rowtmp, &sty_tbl) ||
-				    !HBUF_PUTSL(rowtmp, " "))
-					goto out;
+				if (!rndr_buf_ansi_wrap(st, cellbufs[i],
+				    widths[i] - 1, &cellwrap[i],
+				    &cellnlines[i]))
+					goto out2;
+				if (cellnlines[i] > maxlines)
+					maxlines = cellnlines[i];
 			}
 
-			/*
-			 * Some magic here.
-			 * First, emulate rndr() by setting the
-			 * stackpos to the table, which is required for
-			 * checking the line start.
-			 * Then directly print, as we've already escaped
-			 * all characters, and have embedded escapes of
-			 * our own.  Then end the line.
-			 */
+			/* Output each visual line of this row. */
 
-			st->stackpos++;
-			if (!rndr_stackpos_init(st, n))
-				goto out;
-			if (!rndr_buf_startline(st, ob, n, NULL))
-				goto out;
-			if (!hbuf_putb(ob, rowtmp))
-				goto out;
-			rndr_buf_advance(st, 1);
-			if (!rndr_buf_endline(st, ob, n, NULL))
-				goto out;
-			if (!rndr_buf_vspace(st, ob, n, 1))
-				goto out;
-			st->stackpos--;
+			for (j = 0; j < maxlines; j++) {
+				hbuf_truncate(rowtmp);
+
+				for (i = 0; i < ncols; i++) {
+					struct wrapline	*wl = NULL;
+					size_t		 pad;
+
+					if (j < cellnlines[i])
+						wl = &cellwrap[i][j];
+
+					flags = 0;
+
+					/* Find alignment for this col. */
+
+					TAILQ_FOREACH(cell,
+					    &row->children, entries)
+						if (cell->rndr_table_cell.col
+						    == i) {
+							flags = cell->
+							    rndr_table_cell.
+							    flags &
+							    HTBL_FL_ALIGNMASK;
+							break;
+						}
+
+					pad = (wl != NULL) ?
+					    widths[i] - 1 - wl->viscols :
+					    widths[i] - 1;
+
+					/* Right-align pre-pad. */
+
+					if (flags == HTBL_FL_ALIGN_RIGHT)
+						for (sz = 0; sz < pad; sz++)
+							if (!HBUF_PUTSL(
+							    rowtmp, " "))
+								goto out2;
+
+					/* Centre pre-pad. */
+
+					if (flags == HTBL_FL_ALIGN_CENTER)
+						for (sz = 0;
+						    sz < pad / 2; sz++)
+							if (!HBUF_PUTSL(
+							    rowtmp, " "))
+								goto out2;
+
+					/* Cell content for this line. */
+
+					if (wl != NULL && wl->len > 0) {
+						/*
+						 * Re-open style on
+						 * continuation lines.
+						 */
+						if (j > 0 && wl->sgrlen > 0)
+							if (!hbuf_put(rowtmp,
+							    wl->sgr,
+							    wl->sgrlen))
+								goto out2;
+						if (!hbuf_put(rowtmp,
+						    cellbufs[i]->data +
+						    wl->start, wl->len))
+							goto out2;
+						/*
+						 * Close style if this line
+						 * has unclosed styles.
+						 */
+						if (wl->styled)
+							if (!HBUF_PUTSL(rowtmp,
+							    "\033[0m"))
+								goto out2;
+					}
+
+					/* Left-align or default post-pad. */
+
+					if (flags == 0 ||
+					    flags == HTBL_FL_ALIGN_LEFT)
+						for (sz = 0; sz < pad; sz++)
+							if (!HBUF_PUTSL(
+							    rowtmp, " "))
+								goto out2;
+
+					/* Centre post-pad. */
+
+					if (flags == HTBL_FL_ALIGN_CENTER) {
+						size_t rpad = (pad % 2) ?
+						    (pad / 2) + 1 :
+						    (pad / 2);
+						for (sz = 0;
+						    sz < rpad; sz++)
+							if (!HBUF_PUTSL(
+							    rowtmp, " "))
+								goto out2;
+					}
+
+					/* Column separator. */
+
+					if (i < ncols - 1) {
+						if (!HBUF_PUTSL(
+						    rowtmp, " ") ||
+						    !rndr_buf_style(st,
+						    rowtmp, &sty_tbl) ||
+						    !hbuf_puts(rowtmp,
+						    ifx_tbl_col) ||
+						    !rndr_buf_unstyle(st,
+						    rowtmp, &sty_tbl) ||
+						    !HBUF_PUTSL(
+						    rowtmp, " "))
+							goto out2;
+					}
+				}
+
+				/* Emit the assembled line. */
+
+				st->stackpos++;
+				if (!rndr_stackpos_init(st, n))
+					goto out2;
+				if (!rndr_buf_startline(st, ob, n, NULL))
+					goto out2;
+				if (!hbuf_putb(ob, rowtmp))
+					goto out2;
+				rndr_buf_advance(st, 1);
+				if (!rndr_buf_endline(st, ob, n, NULL))
+					goto out2;
+				if (!rndr_buf_vspace(st, ob, n, 1))
+					goto out2;
+				st->stackpos--;
+			}
+
+			/* Free wrap data for this row. */
+
+			for (i = 0; i < ncols; i++) {
+				free(cellwrap[i]);
+				cellwrap[i] = NULL;
+				cellnlines[i] = 0;
+			}
 		}
 
 		if (top->type == LOWDOWN_TABLE_HEADER) {
 			st->stackpos++;
 			if (!rndr_stackpos_init(st, n))
-				goto out;
+				goto out2;
 			if (!rndr_buf_startline(st, ob, n, &sty_tbl))
-				goto out;
+				goto out2;
 
-			/*
-			 * Output the row line.  This consists of:
-			 *
-			 *   inter    padding
-			 *       |    | |
-			 *       |    | |
-			 *   ----+-----+-----
-			 *   xyz   xyz   xyz
-			 *   |     |
-			 *   content
-			 *
-			 * So starting with the content, ending with a
-			 * padding of one byte (encompassed in the
-			 * width), the inter mark or nothing if at the
-			 * end, then another padding or nothing if at
-			 * the end.
-			 */
 			for (i = 0; i < n->rndr_table.columns; i++) {
 				/* Pre-padding. */
 				if (i > 0 && !hbuf_puts(ob, ifx_tbl_row))
-					goto out;
+					goto out2;
 				/* Content and post-padding. */
 				for (j = 0; j < widths[i]; j++)
 					if (!hbuf_puts(ob, ifx_tbl_row))
-						goto out;
+						goto out2;
 				/* Inter. */
 				if (i < n->rndr_table.columns - 1 &&
 				    !hbuf_puts(ob, ifx_tbl_mcol))
-					goto out;
+					goto out2;
 			}
 			rndr_buf_advance(st, 1);
 			if (!rndr_buf_endline(st, ob, n, &sty_tbl))
-				goto out;
+				goto out2;
 			if (!rndr_buf_vspace(st, ob, n, 1))
-				goto out;
+				goto out2;
 			st->stackpos--;
 		}
 	}
 
 	rc = 1;
+out2:
+	for (i = 0; i < ncols; i++) {
+		free(cellwrap[i]);
+		hbuf_free(cellbufs[i]);
+	}
+	free(cellbufs);
+	free(cellwrap);
+	free(cellnlines);
+	}
+
 out:
 	hbuf_free(celltmp);
 	hbuf_free(rowtmp);

--- a/src/lowdown.h
+++ b/src/lowdown.h
@@ -401,7 +401,7 @@ struct	lowdown_opts {
 #define	LOWDOWN_GEMINI_LINK_ROMAN 0x400000 /* roman link names */
 #define	LOWDOWN_TERM_NOCOLOUR	  0x800000 /* no ANSI colours */
 #define	LOWDOWN_TERM_NOANSI	  0x1000000 /* no ANSI escapes at all */
-/* Missing			  0x2000000 */
+#define	LOWDOWN_TERM_NOBRK	  0x2000000 /* no mid-word breaks */
 #define	LOWDOWN_HTML_TITLEBLOCK	  0x4000000 /* output title block */
 #define LOWDOWN_HTML_CALLOUT_GFM  0x8000000 /* GFM callouts */
 #define LOWDOWN_HTML_CALLOUT_MDN  0x10000000 /* MDN callouts */

--- a/src/main.c
+++ b/src/main.c
@@ -339,6 +339,7 @@ main(int argc, char *argv[])
 
 		{ "term-no-ansi",	no_argument, 	&afl, LOWDOWN_TERM_NOANSI },
 		{ "term-no-colour",	no_argument, 	&afl, LOWDOWN_TERM_NOCOLOUR },
+		{ "term-no-word-break",	no_argument, 	&afl, LOWDOWN_TERM_NOBRK },
 		{ "term-no-rellinks",	no_argument, 	&afl, LOWDOWN_NORELLINK },
 		{ "term-no-links",	no_argument, 	&afl, LOWDOWN_NOLINK },
 		{ "term-short-links",	no_argument, 	&afl, LOWDOWN_SHORTLINK },


### PR DESCRIPTION
## Summary

- Add ANSI-aware word wrapping to tables in `-Tterm` output so they respect `--term-columns` (defaulting to 72 in a pipe). Previously tables rendered at their natural content width, ignoring the column limit.
- After measuring natural column widths, columns that exceed the available width are shrunk widest-first until the table fits. Cells are then word-wrapped to their clamped width, with SGR state tracked and re-opened across continuation lines.
- Add six regression tests covering: basic wrapping, SGR preservation across wrap boundaries, proportional column shrinkage, mixed styles in wrapped cells, single-column tables, and divider alignment with styles across continuation lines.

## Test plan

- [ ] `bmake regress` passes with zero failures (all existing + new tests)
- [ ] Visually verify wrapped table output at various `--term-columns` widths (30, 40, 50, 60, default 72)
- [ ] Verify ANSI styles (bold, italic, strikethrough) are preserved across wrap boundaries (`cat -v` shows SGR re-opened on each continuation line)
- [ ] Verify column dividers align across header, separator, and all continuation lines