### PR TITLE
Allow lists to terminate paragraphs

### DIFF
--- a/src/parse/document.c
+++ b/src/parse/document.c
@@ -2672,6 +2672,18 @@ parse_paragraph(struct lowdown_doc *doc, char *data, size_t size)
 			break;
 		}
 
+        /*
+         * Commonmark allows lists to interrupt paragraphs, so a list prefix
+         * can also end a paragraph in Commonmark mode
+         */
+        if (doc->ext_flags & LOWDOWN_COMMONMARK){
+            if (prefix_uli(doc, data + i, size - i, NULL) ||
+                prefix_oli(doc, data + i, size - i, NULL)){
+                end = i;
+                break;
+            } 
+        } 
+
 		lines++;
 		i = end;
 	}


### PR DESCRIPTION
First of all, thanks for the well-structured and thoroughly-commented code. This change was easy to make.

This PR addresses issue #82: in commonmark mode, a blank line should not be necessary between a paragraph and a list. See the relevant section of the commonmark spec https://spec.commonmark.org/0.31.2/#example-303

Current behaviour: a list following a paragraph without a separating blank line is not parsed as a list. This is correct per `markdown.pl`, but commonmark defines otherwise (the output is a paragraph when it should be a paragraph and a list)

```
$ echo -e "Foo\n- bar\n- baz" | ./lowdown -
<p>Foo
- bar
- baz</p>
```

After this PR: the expected output is generated

```
$ echo -e "Foo\n- bar\n- baz" | ./lowdown -
<p>Foo</p>
<ul>
<li>bar</li>
<li>baz</li>
</ul>
```

It respects the `--parse-no-cmark` flag:

```
$ echo -e "Foo\n- bar\n- baz" | ./lowdown --parse-no-cmark -
<p>Foo
- bar
- baz</p>
```

`bmake regress` shows all tests passing, but I'm not quite sure where to begin adding a test(s) for this change, if that's needed.